### PR TITLE
Added editing/panning modes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,9 +2,6 @@
     <mat-toolbar>
         <span>{{config.boardName ?? 'Sample Board'}}</span>
         <span style="flex: 1 1 auto"></span>
-        <button mat-icon-button (click)="openNewPostDialog()">
-          <mat-icon>add</mat-icon>
-        </button>
         <button mat-icon-button (click)="openTaskDialog()">
             <mat-icon>task</mat-icon>
         </button>
@@ -14,6 +11,19 @@
     </mat-toolbar>
     <div class="canvas-area">
         <canvas id="canvas"></canvas>
+        <div class="toolSection">
+            <div class="toolField">
+                <button mat-fab color="primary" (click)="openNewPostDialog()">
+                    <mat-icon>add</mat-icon>
+                </button>
+                <button *ngIf="mode == modeType.EDIT" mat-fab color="primary" (click)="enablePanMode()">
+                    <mat-icon>edit</mat-icon>
+                </button>
+                <button *ngIf="mode == modeType.PAN" mat-fab color="primary" (click)="enableEditMode()">
+                    <mat-icon>pan_tool</mat-icon>
+                </button>
+            </div>
+          </div>
     </div>
 </div>
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -13,3 +13,24 @@
   box-shadow: 0px 0px 13px 0px;
   margin-top: 20px;
 }
+
+.toolSection {
+  position: absolute;
+  background-color: whitesmoke;
+  padding: 15px;
+  border-radius: 30px;
+  left: 93%;
+}
+
+.toolField {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 20px;
+  margin-top: 0.5rem;
+
+  button {
+    margin-bottom: 10px;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,7 @@ import { ConfigurationModalComponent } from './components/configuration-modal/co
 import { TaskModalComponent } from './components/task-modal/task-modal.component';
 import { ConfigService } from './services/config.service';
 import { PostModalComponent } from './components/post-modal/post-modal.component';
+import { Mode } from './utils/Mode'
 
 // hard-coded for now
 const AUTHOR = 'Ammar-T'
@@ -29,6 +30,8 @@ export class AppComponent {
   postsService: PostService
   configService: ConfigService
   config: any
+  mode: Mode = Mode.EDIT
+  modeType = Mode
 
   constructor(db: AngularFireDatabase, public dialog: MatDialog) {
     this.postsService = new PostService(db, GROUP_ID);
@@ -273,7 +276,7 @@ export class AppComponent {
         _isMouseDown = false;
         var isDragEnd = _isDragging;
         _isDragging = false;
-        if (!isDragEnd) {
+        if (!isDragEnd && this.mode == Mode.EDIT) {
           this.canvas.discardActiveObject().renderAll();
           this.dialog.open(PostModalComponent, {
             width: '500px',
@@ -378,7 +381,7 @@ export class AppComponent {
     var isPanning = false;
 
     this.canvas.on("mouse:down", (opt) => {
-      if (opt.target == null) {
+      if (opt.target == null || this.mode == Mode.PAN) {
         isPanning = true;
         this.canvas.selection = false;
       }
@@ -396,5 +399,19 @@ export class AppComponent {
         this.canvas.relativePan(delta);
       }
     })
+  }
+
+  enablePanMode() {
+    this.mode = Mode.PAN
+    this.lockPostsMovement(true)
+    this.canvas.defaultCursor = 'grab'
+    this.canvas.hoverCursor = 'grab'
+  }
+
+  enableEditMode() {
+    this.mode = Mode.EDIT
+    this.lockPostsMovement(false)
+    this.canvas.defaultCursor = 'pointer'
+    this.canvas.hoverCursor = 'move'
   }
 }

--- a/src/app/utils/Mode.ts
+++ b/src/app/utils/Mode.ts
@@ -1,0 +1,4 @@
+export enum Mode {
+    PAN,
+    EDIT
+}


### PR DESCRIPTION
Board defaults to editing mode. But mode can be changed from toolbar floating on the right side of the canvas.

Panning - allows user to move board around while clicking anywhere (including posts)
Editing - Allows panning + moving posts + editing posts

Closes #23 