### PR TITLE
Change icons for edit and pan modes + alternate when each button appears

### DIFF
--- a/src/app/components/canvas/canvas.component.html
+++ b/src/app/components/canvas/canvas.component.html
@@ -21,10 +21,10 @@
                   <mat-icon>close</mat-icon>
               </button>
               <button *ngIf="mode == modeType.EDIT" mat-fab color="primary" (click)="enablePanMode()">
-                  <mat-icon>edit</mat-icon>
+                  <mat-icon>open_with</mat-icon>
               </button>
               <button *ngIf="mode == modeType.PAN" mat-fab color="primary" (click)="enableEditMode()">
-                  <mat-icon>pan_tool</mat-icon>
+                  <mat-icon>edit_note</mat-icon>
               </button>
           </div>
         </div>


### PR DESCRIPTION
- Change edit mode icon to [edit_note](https://fonts.google.com/icons?icon.query=edit+note)
- Change pan mode icon to [open_with](https://fonts.google.com/icons?icon.query=open+with)
- Alternate when each button appears (pan mode icon appears when edit mode is selected and vice versa)

Closes #55