### PR TITLE
ISSUE-117: Post modal three dot menu issue

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { BucketsModalComponent } from './components/buckets-modal/buckets-modal.
 import { ListModalComponent } from './components/list-modal/list-modal.component';
 import { ToolbarComponent } from './components/toolbar/toolbar.component';
 import { SnackBarComponent } from './components/snackbar/snackbar.component';
+import { ConfirmModalComponent } from './components/confirm-modal/confirm-modal.component';
 
 @NgModule({
   declarations: [
@@ -65,7 +66,8 @@ import { SnackBarComponent } from './components/snackbar/snackbar.component';
     ListModalComponent,
     HtmlPostComponent,
     ToolbarComponent,
-    SnackBarComponent
+    SnackBarComponent,
+    ConfirmModalComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/confirm-modal/confirm-modal.component.html
+++ b/src/app/components/confirm-modal/confirm-modal.component.html
@@ -1,0 +1,6 @@
+<h1 mat-dialog-title>{{title}}</h1>
+<div mat-dialog-content>{{message}}</div>
+<div mat-dialog-actions>
+  <button mat-button mat-dialog-close (click)="handleConfirm()">Confirm</button>
+  <button mat-button mat-dialog-close (click)="handleCancel()">Cancel</button>
+</div>

--- a/src/app/components/confirm-modal/confirm-modal.component.spec.ts
+++ b/src/app/components/confirm-modal/confirm-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmModalComponent } from './confirm-modal.component';
+
+describe('ConfirmModalComponent', () => {
+  let component: ConfirmModalComponent;
+  let fixture: ComponentFixture<ConfirmModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ConfirmModalComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/confirm-modal/confirm-modal.component.ts
+++ b/src/app/components/confirm-modal/confirm-modal.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+export interface ConfirmModalData {
+  title: string,
+  message?: string,
+  handleConfirm?: Function,
+  handleCancel?: Function
+}
+
+@Component({
+  selector: 'app-confirm-modal',
+  templateUrl: './confirm-modal.component.html',
+  styleUrls: ['./confirm-modal.component.scss']
+})
+export class ConfirmModalComponent implements OnInit {
+
+  title: string
+  message?: string
+
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmModalData) {
+      this.title = data.title;
+      this.message = data.message;
+    }
+
+  ngOnInit(): void {}
+
+  handleConfirm() {
+    if (this.data.handleConfirm) {
+      this.data.handleConfirm();
+    }
+  }
+
+  handleCancel() {
+    if (this.data.handleCancel) {
+      this.data.handleCancel();
+    }
+  }
+}

--- a/src/app/components/post-modal/post-modal.component.html
+++ b/src/app/components/post-modal/post-modal.component.html
@@ -18,19 +18,12 @@
         <mat-checkbox id={{bucket.bucketID}} [checked]="bucket.includesPost" (change)="updateBucket($event)">{{ bucket.name }}</mat-checkbox>
       </div>
     </mat-menu>
-    <button mat-icon-button [matMenuTriggerFor]="menu" *ngIf="showEditDelete">
-      <mat-icon>more_vert</mat-icon>
+    <button mat-icon-button *ngIf="!isEditing && showEditDelete && canEditDelete" (click)="toggleEdit()">
+      <mat-icon>edit</mat-icon>
     </button>
-    <mat-menu #menu="matMenu" >
-      <button mat-menu-item *ngIf="!isEditing && canEditDelete" (click)="toggleEdit()">
-        <mat-icon>edit</mat-icon>
-        <span>Edit Post</span>
-      </button>
-      <button mat-menu-item *ngIf="canEditDelete" (click)="onDelete()">
-        <mat-icon>delete</mat-icon>
-        <span>Delete Post</span>
-      </button>
-    </mat-menu>
+    <button mat-icon-button *ngIf="showEditDelete && canEditDelete" (click)="onDelete()">
+      <mat-icon>delete</mat-icon>
+    </button>
   </mat-card-header>
   <mat-card-content>
     <p style="overflow-wrap: break-word;" [innerHTML]="editingDesc"> {{ editingDesc }} </p>

--- a/src/app/components/post-modal/post-modal.component.ts
+++ b/src/app/components/post-modal/post-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MyErrorStateMatcher } from 'src/app/utils/ErrorStateMatcher';
 import Comment from 'src/app/models/comment';
 import { CommentService } from 'src/app/services/comment.service';
@@ -14,6 +14,7 @@ import Post, { Tag } from 'src/app/models/post';
 import { DELETE } from '@angular/cdk/keycodes';
 import { Role } from 'src/app/utils/constants';
 import { POST_COLOR } from 'src/app/utils/constants';
+import { ConfirmModalComponent } from '../confirm-modal/confirm-modal.component';
 
 const linkifyStr = require('linkifyjs/lib/linkify-string');
 
@@ -55,6 +56,7 @@ export class PostModalComponent {
 
   constructor(
     public dialogRef: MatDialogRef<PostModalComponent>,
+    public dialog: MatDialog,
     public commentService: CommentService, public likesService: LikesService,
     public postService: PostService, public bucketService: BucketService,
     public fabricUtils: FabricUtils,
@@ -153,14 +155,24 @@ export class PostModalComponent {
   }
 
   onDelete() {
-    var obj = this.fabricUtils.getObjectFromId(this.post.postID);
+    this.dialog.open(ConfirmModalComponent, {
+      width: '500px',
+      data: {
+        title: 'Confirmation',
+        message: 'Are you sure you want to permanently delete this post?',
+        handleConfirm: () => {
+          this.postService.delete(this.post.postID).then(() => {
+            var obj = this.fabricUtils.getObjectFromId(this.post.postID);
     
-    if (obj && obj.type == 'group') {
-      this.fabricUtils._canvas.remove(obj);
-      this.fabricUtils._canvas.renderAll();
-    }
-
-    this.postService.delete(this.post.postID).then(() => this.dialogRef.close(DELETE))
+            if (obj && obj.type == 'group') {
+              this.fabricUtils._canvas.remove(obj);
+              this.fabricUtils._canvas.renderAll();
+            }
+            this.dialogRef.close(DELETE);
+          })
+        }
+      }
+    });
   }
 
   addTag(event, tagOption): void {


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Before, we had a 3-dot vertical menu with options to edit and delete the post inside the post modal.
- I scrapped the 3-dot menu and just listed the options as buttons since it doesn't make sense to have a whole menu for just 2 buttons
- Also added a confirm dialog when user wants to delete the post

NOTE: You can test it out on staging instead of having to pull locally now. Check the URL I sent in our slack channel.

Closes #117 
