### PR TITLE
ISSUE-210: Fix snackbar CSS/design

### DIFF
--- a/src/app/components/snackbar/snackbar.component.html
+++ b/src/app/components/snackbar/snackbar.component.html
@@ -1,11 +1,11 @@
-<div *ngIf="!description" style="display: flex; flex-direction: row;">
+<div *ngIf="!description" class="actions">
   <div class="title" [innerHTML]="title">
     {{ title }}
   </div>
-  <button mat-stroked-button color="accent" (click)="close()">
+  <button mat-button (click)="close()">
     Close!
   </button>
-  <button mat-stroked-button color="accent" *ngIf="action" (click)="doAction()">
+  <button mat-button *ngIf="action" (click)="doAction()">
     {{ this.action.name }}
   </button>
 </div>
@@ -16,10 +16,12 @@
   <div class="description" [innerHTML]="description">
     {{ description }}
   </div>
-  <button mat-stroked-button color="accent" (click)="close()">
-    Close!
-  </button>
-  <button mat-stroked-button color="accent" *ngIf="action" (click)="doAction()">
-    {{ this.action.name }}
-  </button>
+  <div class="actions complex-actions">
+    <button mat-button (click)="close()">
+      Close!
+    </button>
+    <button mat-button *ngIf="action" (click)="doAction()">
+      {{ this.action.name }}
+    </button>
+  </div>
 </div>

--- a/src/app/components/snackbar/snackbar.component.scss
+++ b/src/app/components/snackbar/snackbar.component.scss
@@ -18,3 +18,13 @@
           line-clamp: 2; 
   -webkit-box-orient: vertical;
 }
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+
+.complex-actions {
+  justify-content: end;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,6 +26,7 @@ $custom-typography: mat.define-typography-config(
 @include mat.menu-theme(light.$ckb-light-theme);
 @include mat.select-theme(light.$ckb-light-theme);
 @include mat.slide-toggle-theme(light.$ckb-light-theme);
+@include mat.snack-bar-theme(light.$ckb-light-theme);
 @include mat.tabs-theme(light.$ckb-light-theme);
 @include mat.toolbar-theme(light.$ckb-light-theme);
 @include mat.tooltip-theme(light.$ckb-light-theme);


### PR DESCRIPTION
## Details
- Restores snackbar styling and background color.
- Improves visibility of snackbar buttons by removing accent color. Accent color doesn't provide enough contrast with the dark background. Colored buttons do look nice, so in the future we can revisit. Maybe we can think about this more in conjunction with #199.
- Adds a little space between snackbar buttons.

Closes #210
