### PR TITLE
ISSUE-243: Make likes from canvas asynchronous

### DIFF
--- a/src/app/components/canvas/canvas.component.ts
+++ b/src/app/components/canvas/canvas.component.ts
@@ -418,10 +418,10 @@ export class CanvasComponent implements OnInit, OnDestroy {
         existing = this.fabricUtils.updatePostTitleDesc(existing, obj.title, obj.desc);
         this.canvas.requestRenderAll()
       } else if (event == CanvasPostEvent.LIKE) {
-        existing = this.fabricUtils.updateLikeCount(existing, obj);
+        existing = this.fabricUtils.copyLikeCount(existing, obj);
         this.canvas.requestRenderAll()
       } else if (event == CanvasPostEvent.COMMENT) {
-        existing = this.fabricUtils.updateCommentCount(existing, obj)
+        existing = this.fabricUtils.copyCommentCount(existing, obj)
         this.canvas.requestRenderAll()
       } else if (event == CanvasPostEvent.NEEDS_ATTENTION_TAG) {
         existing = this.fabricUtils.setBorderColor(existing, NEEDS_ATTENTION_TAG.color);
@@ -459,20 +459,22 @@ export class CanvasComponent implements OnInit, OnDestroy {
     }
   }
 
-  handleLikeEvent = (like: Like, change: string) => {
+  handleLikeEvent = async (like: Like, change: string) => {
     var post = this.fabricUtils.getObjectFromId(like.postID)
     if (post) {
-      post = change == "added" ? this.fabricUtils.incrementLikes(post) : this.fabricUtils.decrementLikes(post)
+      const likes = await this.likesService.getLikesByPost(post.postID);
+      post = this.fabricUtils.setLikeCount(post, likes.docs.length);
       this.canvas.renderAll()
       var jsonPost = this.fabricUtils.toJSON(this.fabricUtils.attachEvent(post, CanvasPostEvent.LIKE));
       this.postService.update(post.postID, { fabricObject: jsonPost })
     }
   }
 
-  handleCommentEvent = (comment: Comment) => {
+  handleCommentEvent = async (comment: Comment) => {
     var post = this.fabricUtils.getObjectFromId(comment.postID)
     if (post) {
-      post = this.fabricUtils.incrementComments(post)
+      const comments = await this.commentService.getCommentsByPost(post.postID);
+      post = this.fabricUtils.setCommentCount(post, comments.docs.length);
       this.canvas.renderAll()
       var jsonPost = this.fabricUtils.toJSON(this.fabricUtils.attachEvent(post, CanvasPostEvent.COMMENT));
       this.postService.update(post.postID, { fabricObject: jsonPost })
@@ -480,35 +482,41 @@ export class CanvasComponent implements OnInit, OnDestroy {
   }
 
   initLikeClickListener() {
-    this.canvas.on('mouse:down', this.handleLikeClick);
+    let waiting = false;
+
+    const handleAsyncLikes = async (e) => {
+      if (!waiting) {
+        waiting = true;
+        await this.handleLikeClick(e);
+        waiting = false;
+      }
+    }
+
+    this.canvas.on('mouse:down', handleAsyncLikes);
 
     return () => { 
-      this.canvas.off('mouse:down', this.handleLikeClick)
+      this.canvas.off('mouse:down', handleAsyncLikes);
     };
   }
 
-  handleLikeClick = (e: fabric.IEvent) => {
+  handleLikeClick = async (e: fabric.IEvent) => {
     var post: any = e.target
     var likeButton = e.subTargets?.find(o => o.name == 'like')
     let isStudent = this.user.role == Role.STUDENT
     let isTeacher = this.user.role == Role.TEACHER
     let studentHasPerm = isStudent && this.board.permissions.allowStudentLiking
     if (likeButton && (studentHasPerm || isTeacher)) {
-      this.likesService.isLikedBy(post.postID, this.user.id).then((data) => {
-        if (data.size == 0) {
-          this.likesService.add({
-            likeID: Date.now() + '-' + this.user.id,
-            likerID: this.user.id,
-            postID: post.postID,
-            boardID: this.board.boardID
-          })
-        } else {
-          data.forEach((data) => {
-            let like: Like = data.data()
-            this.likesService.remove(like.likeID)
-          })
-        }
-      })
+      let [like, isLiked] = await this.likesService.isLikedBy(post.postID, this.user.id);
+      if (!isLiked) {
+        await this.likesService.add({
+          likeID: Date.now() + '-' + this.user.id,
+          likerID: this.user.id,
+          postID: post.postID,
+          boardID: this.board.boardID
+        })
+      } else {
+        await this.likesService.remove(like.likeID)
+      }
     }
   }
 

--- a/src/app/services/likes.service.ts
+++ b/src/app/services/likes.service.ts
@@ -30,19 +30,22 @@ export class LikesService {
     })
   }
 
-  getLikesByPost(postID: string) {
+  async getLikesByPost(postID: string) {
     return this.likesCollection.ref.where("postID", "==", postID).get().then((snapshot) => snapshot)
   }
 
-  isLikedBy(postID: string, likerID: string) {
-    return this.likesCollection.ref.where("postID", "==", postID).where("likerID", "==", likerID).get().then((snapshot) => snapshot)
+  async isLikedBy(postID: string, likerID: string): Promise<[any, boolean]> {
+    return this.likesCollection.ref.where("postID", "==", postID).where("likerID", "==", likerID).get().then((snapshot) => {
+      if (snapshot.size == 0) return [null, false];
+      return [snapshot.docs[0].data(), true];
+    })
   }
 
-  add(like: Like): any {
+  add(like: Like): Promise<void> {
     return this.likesCollection.doc(like.likeID).set(like)
   }
 
-  remove(likeID: string) {
+  remove(likeID: string): Promise<void> {
     return this.likesCollection.ref.doc(likeID).delete()
   }
 }

--- a/src/app/utils/FabricUtils.ts
+++ b/src/app/utils/FabricUtils.ts
@@ -181,70 +181,28 @@ export class FabricUtils {
         return obj
     }
 
-    updateLikeCount(existing, obj) {
-        var likeCountExisting: any = existing.getObjects().find((obj) => obj.name == 'likeCount')
+    copyLikeCount(existing, obj) {
         var likeCountObj: any = obj.objects.find((obj) => obj.name == 'likeCount')
-
-        likeCountExisting.set({ text: likeCountObj.text, dirty: true })
-
-        existing.dirty = true
-        existing.addWithUpdate();
-        return existing
+        return this.setLikeCount(existing, likeCountObj.text);
     }
 
-    incrementLikes(obj: any) {
-        var children: fabric.Object[] = obj.getObjects()
-        var likeCountObj: any = children.find((obj) => obj.name == 'likeCount')
-
-        var numlikes = parseInt(likeCountObj.text)
-        likeCountObj.set({ text: (numlikes + 1).toString(), dirty: true })
-
-        obj.dirty = true
-        obj.addWithUpdate();
-        return obj
-    }
-
-    decrementLikes(obj: any) {
-        var children: fabric.Object[] = obj.getObjects()
-        var likeCountObj: any = children.find((obj) => obj.name == 'likeCount')
-
-        var numlikes = parseInt(likeCountObj.text)
-        likeCountObj.set({ text: (numlikes - 1).toString(), dirty: true })
+    setLikeCount(obj, count: number) {
+        var likeCountExisting: any = obj.getObjects().find((obj) => obj.name == 'likeCount')
+        likeCountExisting.set({ text: count.toString(), dirty: true })
 
         obj.dirty = true
         obj.addWithUpdate();
         return obj
     }
     
-    updateCommentCount(existing, obj) {
-        var commentCountExisting: any = existing.getObjects().find((obj) => obj.name == 'commentCount')
+    copyCommentCount(existing, obj) {
         var commentCountObj: any = obj.objects.find((obj) => obj.name == 'commentCount')
-
-        commentCountExisting.set({ text: commentCountObj.text, dirty: true })
-
-        existing.dirty = true
-        existing.addWithUpdate();
-        return existing
+        return this.setCommentCount(existing, commentCountObj.text);
     }
 
-    incrementComments(obj: any) {
-        var children: fabric.Object[] = obj.getObjects()
-        var commentCountObj: any = children.find((obj) => obj.name == 'commentCount')
-
-        var numComments = parseInt(commentCountObj.text)
-        commentCountObj.set({ text: (numComments + 1).toString(), dirty: true })
-
-        obj.dirty = true
-        obj.addWithUpdate();
-        return obj
-    }
-
-    decrementComments(obj: any) {
-        var children: fabric.Object[] = obj.getObjects()
-        var commentCountObj: any = children.find((obj) => obj.name == 'commentCount')
-
-        var numComments = parseInt(commentCountObj.text)
-        commentCountObj.set({ text: (numComments - 1).toString(), dirty: true })
+    setCommentCount(obj, count: number) {
+        var commentCountObj: any = obj.getObjects().find((obj) => obj.name == 'commentCount')
+        commentCountObj.set({ text: count.toString(), dirty: true })
 
         obj.dirty = true
         obj.addWithUpdate();


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Each time the like button is clicked, instead of incrementing/decrementing the value by 1, we check the db for total likes first. This is to stop race conditions which cause the like amounts to be inaccurate.
- Also made liking posts from canvas async which fixes the issue of clicking the like button twice really quickly causing the number to go up by 2. Obviously, this should never happen since one user can only like a post once.

Closes #243 
