### PR TITLE
Add permission to hide buckets from students

### DIFF
--- a/src/app/components/add-board-modal/add-board-modal.component.html
+++ b/src/app/components/add-board-modal/add-board-modal.component.html
@@ -37,6 +37,7 @@
       </mat-form-field>
     </mat-tab>
     <mat-tab label="Permissions">
+      <h2 style="margin-top: 20px;">Post Features</h2>
       <p>
         <mat-checkbox [(ngModel)]="permissions.allowStudentMoveAny">Allow students to move any post</mat-checkbox>
       </p>
@@ -52,12 +53,14 @@
       <p>
         <mat-checkbox [(ngModel)]="permissions.allowStudentTagging" >Allow students to tag posts</mat-checkbox>
       </p>
+      <h2>Anonymization</h2>
       <p>
         <mat-checkbox [(ngModel)]="permissions.showAuthorNameStudent" >Show author names to students</mat-checkbox>
       </p>
       <p>
         <mat-checkbox [(ngModel)]="permissions.showAuthorNameTeacher" >Show author names to teachers</mat-checkbox>
       </p>
+      <h2>UI Elements</h2>
       <p>
         <mat-checkbox [(ngModel)]="permissions.showBucketStudent" >Show buckets to students</mat-checkbox>
       </p>

--- a/src/app/components/add-board-modal/add-board-modal.component.html
+++ b/src/app/components/add-board-modal/add-board-modal.component.html
@@ -58,6 +58,9 @@
       <p>
         <mat-checkbox [(ngModel)]="permissions.showAuthorNameTeacher" >Show author names to teachers</mat-checkbox>
       </p>
+      <p>
+        <mat-checkbox [(ngModel)]="permissions.showBucketStudent" >Show buckets to students</mat-checkbox>
+      </p>
     </mat-tab>
     <mat-tab label="Tags">
       <div class="tags-list">

--- a/src/app/components/add-board-modal/add-board-modal.component.ts
+++ b/src/app/components/add-board-modal/add-board-modal.component.ts
@@ -47,7 +47,8 @@ export class AddBoardModalComponent implements OnInit {
       allowStudentCommenting: true,
       allowStudentTagging: true,
       showAuthorNameStudent: true,
-      showAuthorNameTeacher: true
+      showAuthorNameTeacher: true,
+      showBucketStudent: true,
     }
     this.projects = data.projects
     this.selectedProject = data.defaultProject || ''

--- a/src/app/components/canvas/canvas.component.html
+++ b/src/app/components/canvas/canvas.component.html
@@ -9,7 +9,7 @@
       <button mat-icon-button *ngIf="user && user.role == Role.TEACHER" (click)="openWorkflowDialog()" matTooltip="Workflows">
         <mat-icon>timeline</mat-icon>
       </button>
-      <button mat-icon-button (click)="showBucketsModal()" matTooltip="View Buckets">
+      <button mat-icon-button *ngIf="!(user && user.role == Role.STUDENT && !board.permissions.showBucketStudent)" (click)="showBucketsModal()" matTooltip="View Buckets">
         <mat-icon>shopping_basket</mat-icon>
       </button>
       <button mat-icon-button (click)="showListModal()" matTooltip="List Posts">

--- a/src/app/components/configuration-modal/configuration-modal.component.html
+++ b/src/app/components/configuration-modal/configuration-modal.component.html
@@ -35,6 +35,7 @@
       </mat-form-field>
     </mat-tab>
     <mat-tab label="Permissions">
+      <h2 style="margin-top: 20px;">Post Features</h2>
       <p>
         <mat-checkbox [(ngModel)]="permissions.allowStudentMoveAny">Allow students to move any post</mat-checkbox>
       </p>
@@ -50,12 +51,14 @@
       <p>
         <mat-checkbox [(ngModel)]="permissions.allowStudentTagging" >Allow students to tag posts</mat-checkbox>
       </p>
+      <h2>Anonymization</h2>
       <p>
         <mat-checkbox [(ngModel)]="permissions.showAuthorNameStudent" >Show author names to students</mat-checkbox>
       </p>
       <p>
         <mat-checkbox [(ngModel)]="permissions.showAuthorNameTeacher" >Show author names to teachers</mat-checkbox>
       </p>
+      <h2>UI Elements</h2>
       <p>
         <mat-checkbox [(ngModel)]="permissions.showBucketStudent" >Show buckets to students</mat-checkbox>
       </p>

--- a/src/app/components/configuration-modal/configuration-modal.component.html
+++ b/src/app/components/configuration-modal/configuration-modal.component.html
@@ -56,6 +56,9 @@
       <p>
         <mat-checkbox [(ngModel)]="permissions.showAuthorNameTeacher" >Show author names to teachers</mat-checkbox>
       </p>
+      <p>
+        <mat-checkbox [(ngModel)]="permissions.showBucketStudent" >Show buckets to students</mat-checkbox>
+      </p>
     </mat-tab>
     <mat-tab label="Tags">
       <div class="tags-list">

--- a/src/app/models/permissions.ts
+++ b/src/app/models/permissions.ts
@@ -2,8 +2,9 @@ export class Permissions{
     allowStudentMoveAny: boolean;
     allowStudentLiking: boolean;
     allowStudentEditAddDeletePost: boolean;
-    allowStudentCommenting:boolean;
-    allowStudentTagging:boolean;
-    showAuthorNameStudent:boolean;
-    showAuthorNameTeacher:boolean;
+    allowStudentCommenting: boolean;
+    allowStudentTagging: boolean;
+    showAuthorNameStudent: boolean;
+    showAuthorNameTeacher: boolean;
+    showBucketStudent: boolean;
 }


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- teachers can set the permission when adding a board or updating configuration


Closes #257 
