### PR TITLE
Fix 'Mixed' property warnings

### DIFF
--- a/backend/src/models/Board.ts
+++ b/backend/src/models/Board.ts
@@ -1,5 +1,13 @@
-import { prop, getModelForClass, modelOptions } from '@typegoose/typegoose';
+import {
+  prop,
+  getModelForClass,
+  modelOptions,
+  Severity,
+  setGlobalOptions,
+} from '@typegoose/typegoose';
 import { TagModel } from './Tag';
+
+setGlobalOptions({ options: { allowMixed: Severity.ALLOW } });
 
 export class TaskModel {
   @prop({ required: false })

--- a/backend/src/models/Trace.ts
+++ b/backend/src/models/Trace.ts
@@ -1,6 +1,14 @@
-import { getModelForClass, modelOptions, prop } from '@typegoose/typegoose';
+import {
+  getModelForClass,
+  modelOptions,
+  prop,
+  Severity,
+} from '@typegoose/typegoose';
 
-@modelOptions({ schemaOptions: { collection: 'trace', timestamps: true } })
+@modelOptions({
+  schemaOptions: { collection: 'trace', timestamps: true },
+  options: { allowMixed: Severity.ALLOW },
+})
 export class TraceModel {
   @prop({ required: true })
   projectID!: string;


### PR DESCRIPTION
## Details
I called the branch issue-294, but looking back, I'm not actually sure that this is what 294 was talking about lol. Basically this removes the 
```
Setting "Mixed" for property "TraceModel.event"
Look here for how to disable this message: https://typegoose.github.io/typegoose/docs/api/decorators/model-options/#allowmixed
```

type of warnings that were on the backend.

