### PR TITLE
Issue 313 - Blank tag logs for un-submitted posts

### DIFF
--- a/frontend/src/app/services/canvas.service.ts
+++ b/frontend/src/app/services/canvas.service.ts
@@ -41,6 +41,12 @@ export class CanvasService {
 
     this.fabricUtils._canvas.add(fabricPost);
     this.socketService.emit(SocketEvent.POST_CREATE, savedPost);
+    for (const tag of post.tags) {
+      this.socketService.emit(SocketEvent.POST_TAG_ADD, {
+        tag,
+        post: savedPost,
+      });
+    }
   }
 
   async removePost(post: Post) {


### PR DESCRIPTION
## Details
- Fixes bug where tags added during post creation weren't being added to the trace logs.


Closes #313 
