### PR TITLE
Fix anonymity bug and author name leaks

### DIFF
--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -336,6 +336,7 @@ export class CanvasComponent implements OnInit, OnDestroy {
   }
 
   configureBoard() {
+    console.log('configuring board');
     const map = this.activatedRoute.snapshot.paramMap;
 
     if (map.has('boardID') && map.has('projectID')) {
@@ -360,6 +361,7 @@ export class CanvasComponent implements OnInit, OnDestroy {
             new FabricPostComponent(post, {
               upvotes: upvotes.length,
               comments: comments.length,
+              author: 'Anonymous',
             })
           );
         }

--- a/frontend/src/app/components/fabric-post/fabric-post.component.ts
+++ b/frontend/src/app/components/fabric-post/fabric-post.component.ts
@@ -15,6 +15,7 @@ const CONTENT_EXTRA_HEIGHT = 55;
 export interface PostOptions {
   upvotes: number;
   comments: number;
+  author?: string;
 }
 
 @Component({
@@ -39,16 +40,19 @@ export class FabricPostComponent extends fabric.Group {
       splitByGrapheme: true,
     });
 
-    const author = new fabric.Textbox(post.author, {
-      name: 'author',
-      width: 300,
-      left: 18,
-      top: title.getScaledHeight() + AUTHOR_OFFSET,
-      fontSize: 13,
-      fontFamily: 'Helvetica',
-      fill: '#555555',
-      splitByGrapheme: true,
-    });
+    const author = new fabric.Textbox(
+      options?.author?.toString() ?? post.author,
+      {
+        name: 'author',
+        width: 300,
+        left: 18,
+        top: title.getScaledHeight() + AUTHOR_OFFSET,
+        fontSize: 13,
+        fontFamily: 'Helvetica',
+        fill: '#555555',
+        splitByGrapheme: true,
+      }
+    );
 
     const desc = new fabric.Textbox(
       post.desc.length > 200 ? post.desc.substr(0, 200) + '...' : post.desc,


### PR DESCRIPTION
## Details

- I was getting a bug where if a board is supposed to be anonymous,  refreshing the page causes some posts to be anonymous and others to have the correct name, like in this picture:

![image](https://user-images.githubusercontent.com/35171619/177466223-f0a4ac39-7c4a-4d8d-995b-f1c410c7386e.png)

To recreate:

1. Create a new board using teacher, and have a student account join it.
2. Make some posts with the student account.
3. Teacher account unchecks the permission boxes that allows teachers and students to see post name, and updates the configuration. (this can also be done now, or in the very beginning)
4. Then if you access the board from any account (teacher, student who made the posts, or another student), and keep refreshing, you'll reach a state where one or more of the posts aren't anonymized.

- Also, refreshing the page could lead to an author's name being shown for a split second before it switched to anonymous.
- This fix is meant to fix the bug and the author name leak.


