### PR TITLE
Open task snack bar functionality 

### DIFF
--- a/backend/src/models/Board.ts
+++ b/backend/src/models/Board.ts
@@ -43,6 +43,9 @@ export class PermissionsModel {
   public showBucketStudent!: boolean;
 
   @prop({ required: true })
+  public showSnackBarStudent!: boolean;
+
+  @prop({ required: true })
   public allowTracing!: boolean;
 }
 

--- a/frontend/src/app/components/add-board-modal/add-board-modal.component.html
+++ b/frontend/src/app/components/add-board-modal/add-board-modal.component.html
@@ -133,6 +133,11 @@
           >Show buckets to students</mat-checkbox
         >
       </p>
+      <p>
+        <mat-checkbox [(ngModel)]="permissions.showSnackBarStudent"
+          >Open task snackbar when board accessed</mat-checkbox
+        >
+      </p>
     </mat-tab>
     <mat-tab label="Tags">
       <div class="tags-list">

--- a/frontend/src/app/components/add-board-modal/add-board-modal.component.ts
+++ b/frontend/src/app/components/add-board-modal/add-board-modal.component.ts
@@ -59,6 +59,7 @@ export class AddBoardModalComponent implements OnInit {
       showAuthorNameStudent: true,
       showAuthorNameTeacher: true,
       showBucketStudent: true,
+      showSnackBarStudent: false,
       allowTracing: false,
     };
     this.projects = data.projects;

--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -379,6 +379,9 @@ export class CanvasComponent implements OnInit, OnDestroy {
           );
           this.updateShowAddPost(this.board.permissions);
           this.setAuthorVisibilityAll();
+          if (this.board.permissions.showSnackBarStudent) {
+            this.openTaskDialog();
+          }
         }
       });
     });

--- a/frontend/src/app/components/configuration-modal/configuration-modal.component.html
+++ b/frontend/src/app/components/configuration-modal/configuration-modal.component.html
@@ -145,6 +145,11 @@
           >Show buckets to students</mat-checkbox
         >
       </p>
+      <p>
+        <mat-checkbox [(ngModel)]="permissions.showSnackBarStudent"
+          >Open task snackbar when board accessed</mat-checkbox
+        >
+      </p>
     </mat-tab>
     <mat-tab label="Tags">
       <div class="tags-list">

--- a/frontend/src/app/models/board.ts
+++ b/frontend/src/app/models/board.ts
@@ -20,6 +20,7 @@ export class BoardPermissions {
   showAuthorNameStudent: boolean;
   showAuthorNameTeacher: boolean;
   showBucketStudent: boolean;
+  showSnackBarStudent: boolean;
   allowTracing: boolean;
 }
 


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details
- Opening task snack bar when board is opened permission added
- Permission is false by default
<img width="449" alt="Screen Shot 2022-07-06 at 4 23 50 PM" src="https://user-images.githubusercontent.com/73078183/177636565-5f12f1dc-8014-4b4e-b4da-89147aa31a0f.png">

Closes #238 
