### PR TITLE
Students can edit/delete own posts

### DIFF
--- a/frontend/src/app/components/fabric-post/fabric-post.component.ts
+++ b/frontend/src/app/components/fabric-post/fabric-post.component.ts
@@ -176,6 +176,7 @@ export class FabricPostComponent extends fabric.Group {
       name: 'post',
       postID: post.postID,
       left: position.left,
+      userID: post.userID,
       top: position.top,
       hasControls: false,
       transparentCorners: false,

--- a/frontend/src/app/components/post-modal/post-modal.component.ts
+++ b/frontend/src/app/components/post-modal/post-modal.component.ts
@@ -103,7 +103,7 @@ export class PostModalComponent {
         (n) => !this.tags.map((b) => b.name).includes(n.name)
       );
       this.canEditDelete =
-        this.data.post.authorID == this.user.userID ||
+        this.data.post.userID == this.user.userID ||
         this.user.role == Role.TEACHER;
       this.author = await this.userService.getOneById(p.userID);
     });


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Slight tweak in code so that students can edit/delete their own posts (not others)
- Teachers can still edit/delete all posts 


Closes #321
