### PR TITLE
Hotfix: Handle null background image settings

### DIFF
--- a/frontend/src/app/components/configuration-modal/configuration-modal.component.ts
+++ b/frontend/src/app/components/configuration-modal/configuration-modal.component.ts
@@ -119,6 +119,7 @@ export class ConfigurationModalComponent {
       this.data.update(board);
       this.currentBgImage = board.bgImage;
       if (board.bgImage) {
+        this.bgImgSettings = board.bgImage.imgSettings;
         this.backgroundPosX = board.bgImage.imgSettings.left;
         this.backgroundPosY = board.bgImage.imgSettings.top;
         this.backgroundScale = board.bgImage


### PR DESCRIPTION
Background image settings not being updated in the client after an image is first uploaded.

<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Background image settings were not being set in the client after a background image upload. This caused an error when attempting to update the board configuration.


