### PR TITLE
ISSUE-432: Do not create trace event when tracing disabled

### DIFF
--- a/backend/src/socket/events/post.events.ts
+++ b/backend/src/socket/events/post.events.ts
@@ -178,7 +178,8 @@ class PostCommentRemove {
   ): Promise<object> {
     const comment = input.eventData;
     const commentAmount = await dalComment.getAmountByPost(comment.postID);
-    await postTrace.commentRemove(input, this.type);
+    if (input.trace.allowTracing)
+      await postTrace.commentRemove(input, this.type);
 
     WorkflowManager.Instance.updateTask(
       comment.userID,


### PR DESCRIPTION
## Details

- Checks if tracing is enabled before attempting to create a trace event for comment deletions.


Closes #432 
