### PR TITLE
feat(canvas): Prevent event propagation of board scroll and pan

### DIFF
--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -4,6 +4,7 @@ import {
   OnInit,
   ViewChild,
   TemplateRef,
+  HostListener,
 } from '@angular/core';
 import { fabric } from 'fabric';
 import { Canvas } from 'fabric/fabric-impl';
@@ -94,6 +95,12 @@ export class CanvasComponent implements OnInit, OnDestroy {
   upvoteCounter = 0;
 
   unsubListeners: Subscription[] = [];
+
+  @HostListener('wheel', ['$event'])
+  onMouseWheel(e: WheelEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
 
   constructor(
     public postService: PostService,


### PR DESCRIPTION
## Details
When user scrolls or pans a board with the mousewheel or trackpad, event propagation is stopped. This should prevent the parent of the iframe that an embedded board is loaded in from also scrolling.

Closes #383.
