### PR TITLE
Re-Activate/Cancel Tasks

### DIFF
--- a/backend/src/api/workflows.ts
+++ b/backend/src/api/workflows.ts
@@ -327,25 +327,14 @@ router.post('/task/groupTask/:groupTaskID/submit', async (req, res) => {
 });
 
 /**
- * Mark group task as complete.
+ * Update Group Task status to Complete/Active
  */
-router.post('/task/groupTask/:groupTaskID/complete', async (req, res) => {
+router.post('/task/groupTask/:groupTaskID/status', async (req, res) => {
   const { groupTaskID } = req.params;
+  const { status } = req.body;
 
   const updatedGroupTask = await dalGroupTask.update(groupTaskID, {
-    status: GroupTaskStatus.COMPLETE,
-  });
-  res.status(200).json(updatedGroupTask);
-});
-
-/**
- * Mark group task as active.
- */
-router.post('/task/groupTask/:groupTaskID/active', async (req, res) => {
-  const { groupTaskID } = req.params;
-
-  const updatedGroupTask = await dalGroupTask.update(groupTaskID, {
-    status: GroupTaskStatus.ACTIVE,
+    status: status,
   });
   res.status(200).json(updatedGroupTask);
 });

--- a/backend/src/api/workflows.ts
+++ b/backend/src/api/workflows.ts
@@ -338,4 +338,16 @@ router.post('/task/groupTask/:groupTaskID/complete', async (req, res) => {
   res.status(200).json(updatedGroupTask);
 });
 
+/**
+ * Mark group task as active.
+ */
+router.post('/task/groupTask/:groupTaskID/active', async (req, res) => {
+  const { groupTaskID } = req.params;
+
+  const updatedGroupTask = await dalGroupTask.update(groupTaskID, {
+    status: GroupTaskStatus.ACTIVE,
+  });
+  res.status(200).json(updatedGroupTask);
+});
+
 export default router;

--- a/frontend/src/app/components/ck-monitor/ck-monitor.component.html
+++ b/frontend/src/app/components/ck-monitor/ck-monitor.component.html
@@ -251,6 +251,7 @@
           <tr mat-row *matRowDef="let row; columns: todoColumns;"></tr>
         </table>
       </div>
+      <mat-progress-bar style="margin: 20px; width: 95%" mode="indeterminate" *ngIf="loading"></mat-progress-bar>
       <div class="heading no-workflow-select" *ngIf="!runningTask && !todoIsVisible">
         No task selected!
       </div>
@@ -279,11 +280,18 @@
                 <ng-container matColumnDef="action">
                   <th mat-header-cell *matHeaderCellDef > {{ runningTaskGroupStatus === GroupTaskStatus.INACTIVE ? "" : "Action"}} </th>
                   <td mat-cell *matCellDef="let group"> 
-                    <button mat-icon-button (click)="runningTaskGroupStatus === GroupTaskStatus.COMPLETE ? activateGroupTask(group) : completeGroupTask(group)" matTooltip="Edit Task">
-                      <mat-icon *ngIf="runningTaskGroupStatus === GroupTaskStatus.COMPLETE">
+                    <button 
+                      *ngIf="runningTaskGroupStatus !== GroupTaskStatus.INACTIVE" mat-icon-button 
+                      (click)="
+                        runningTaskGroupStatus === GroupTaskStatus.COMPLETE 
+                        ? activateGroupTask(group) 
+                        : completeGroupTask(group)"
+                      
+                    >
+                      <mat-icon matTooltip="Re-activate Task" *ngIf="runningTaskGroupStatus === GroupTaskStatus.COMPLETE">
                         play_circle_outline
                       </mat-icon>
-                      <mat-icon *ngIf="runningTaskGroupStatus === GroupTaskStatus.ACTIVE">
+                      <mat-icon matTooltip="Cancel Task" *ngIf="runningTaskGroupStatus === GroupTaskStatus.ACTIVE">
                         cancel
                       </mat-icon>
                     </button>  

--- a/frontend/src/app/components/ck-monitor/ck-monitor.component.html
+++ b/frontend/src/app/components/ck-monitor/ck-monitor.component.html
@@ -34,20 +34,23 @@
             <h3 matLine> {{workflow.name}} </h3>
             <p matLine class="list-task-prompt"> {{workflow.prompt}} </p>
             <p matLine class="list-task-prompt"> 
-              Groups: {{taskWorkflowGroupNameMap.get(workflow)?.join(', ')}} 
+              Groups:
+              <span *ngFor="let group of taskWorkflowNameMap.get(workflow)">
+                {{group.groupName}}&nbsp;
+              </span>
             </p>
             <span style="flex: 1 1 auto"></span>
             <button
-              *ngIf="(runningTask && runningTask.workflowID !== workflow.workflowID) || (!runningTask)"
+              *ngIf="(runningTask && (runningTask.workflowID !== workflow.workflowID || runningTaskGroupStatus !== GroupTaskStatus.INACTIVE)) || (!runningTask)"
               mat-raised-button
               color="primary"
               class="sidebar-button"
-              (click)="view(workflow)"
+              (click)="view(workflow, GroupTaskStatus.INACTIVE)"
             >
               Monitor Task
             </button>
             <button
-              *ngIf="runningTask && runningTask.workflowID === workflow.workflowID"
+              *ngIf="runningTask && runningTask.workflowID === workflow.workflowID && runningTaskGroupStatus === GroupTaskStatus.INACTIVE"
               mat-raised-button
               color="primary"
               class="sidebar-button"
@@ -68,20 +71,25 @@
             <h3 matLine> {{workflow.name}} </h3>
             <p matLine class="list-task-prompt"> {{workflow.prompt}} </p>
             <p matLine class="list-task-prompt"> 
-              Groups: {{taskWorkflowGroupNameMap.get(workflow)?.join(', ')}} 
+              Groups:
+              <span *ngFor="let group of taskWorkflowNameMap.get(workflow)">
+                <span *ngIf="group.groupStatus === GroupTaskStatus.ACTIVE">
+                  {{group.groupName}}&nbsp;
+                </span>
+              </span>
             </p>
             <span style="flex: 1 1 auto"></span>
             <button
-              *ngIf="(runningTask && runningTask.workflowID !== workflow.workflowID) || (!runningTask)"
+              *ngIf="(runningTask && (runningTask.workflowID !== workflow.workflowID || runningTaskGroupStatus !== GroupTaskStatus.ACTIVE)) || (!runningTask)"
               mat-raised-button
               color="primary"
               class="sidebar-button"
-              (click)="view(workflow)"
+              (click)="view(workflow, GroupTaskStatus.ACTIVE)"
             >
               Monitor Task
             </button>
             <button
-              *ngIf="runningTask && runningTask.workflowID === workflow.workflowID"
+              *ngIf="runningTask && runningTask.workflowID === workflow.workflowID && runningTaskGroupStatus === GroupTaskStatus.ACTIVE"
               mat-raised-button
               color="primary"
               class="sidebar-button"
@@ -102,20 +110,25 @@
             <h3 matLine> {{workflow.name}} </h3>
             <p matLine class="list-task-prompt"> {{workflow.prompt}} </p>
             <p matLine class="list-task-prompt"> 
-              Groups: {{taskWorkflowGroupNameMap.get(workflow)?.join(', ')}} 
+              Groups:
+              <span *ngFor="let group of taskWorkflowNameMap.get(workflow)">
+                <span *ngIf="group.groupStatus === GroupTaskStatus.COMPLETE">
+                  {{group.groupName}}&nbsp;
+                </span>
+              </span>
             </p>
             <span style="flex: 1 1 auto"></span>
             <button
-              *ngIf="(runningTask && runningTask.workflowID !== workflow.workflowID) || (!runningTask)"
+              *ngIf="(runningTask && (runningTask.workflowID !== workflow.workflowID || runningTaskGroupStatus !== GroupTaskStatus.COMPLETE)) || (!runningTask)"
               mat-raised-button
               color="primary"
               class="sidebar-button"
-              (click)="view(workflow)"
+              (click)="view(workflow, GroupTaskStatus.COMPLETE)"
             >
               Monitor Task
             </button>
             <button
-              *ngIf="runningTask && runningTask.workflowID === workflow.workflowID"
+              *ngIf="runningTask && runningTask.workflowID === workflow.workflowID && runningTaskGroupStatus === GroupTaskStatus.COMPLETE"
               mat-raised-button
               color="primary"
               class="sidebar-button"
@@ -261,6 +274,20 @@
                 <ng-container matColumnDef="progress">
                   <th mat-header-cell *matHeaderCellDef> Progress </th>
                   <td mat-cell *matCellDef="let group"> {{group.progress}} % </td>
+                </ng-container>
+
+                <ng-container matColumnDef="action">
+                  <th mat-header-cell *matHeaderCellDef > {{ runningTaskGroupStatus === GroupTaskStatus.INACTIVE ? "" : "Action"}} </th>
+                  <td mat-cell *matCellDef="let group"> 
+                    <button mat-icon-button (click)="runningTaskGroupStatus === GroupTaskStatus.COMPLETE ? activateGroupTask(group) : completeGroupTask(group)" matTooltip="Edit Task">
+                      <mat-icon *ngIf="runningTaskGroupStatus === GroupTaskStatus.COMPLETE">
+                        play_circle_outline
+                      </mat-icon>
+                      <mat-icon *ngIf="runningTaskGroupStatus === GroupTaskStatus.ACTIVE">
+                        cancel
+                      </mat-icon>
+                    </button>  
+                  </td>
                 </ng-container>
 
             

--- a/frontend/src/app/components/ck-monitor/ck-monitor.component.html
+++ b/frontend/src/app/components/ck-monitor/ck-monitor.component.html
@@ -39,7 +39,9 @@
             <p matLine class="list-task-prompt"> 
               Groups:
               <span *ngFor="let group of taskWorkflowNameMap.get(workflow)">
-                {{group.groupName}}&nbsp;
+                <span *ngIf="group.groupStatus === GroupTaskStatus.INACTIVE">
+                  {{group.groupName}}&nbsp;
+                </span>
               </span>
             </p>
             <span style="flex: 1 1 auto"></span>

--- a/frontend/src/app/components/ck-monitor/ck-monitor.component.scss
+++ b/frontend/src/app/components/ck-monitor/ck-monitor.component.scss
@@ -127,3 +127,10 @@ mat-sidenav-content {
   width: 100%;
 }
 
+.mat-column-progress{
+  padding: 0 8px;
+}
+
+.mat-column-action{
+  padding: 0 8px;
+}

--- a/frontend/src/app/components/ck-monitor/ck-monitor.component.ts
+++ b/frontend/src/app/components/ck-monitor/ck-monitor.component.ts
@@ -262,14 +262,10 @@ export class CkMonitorComponent implements OnInit, OnDestroy {
         );
       }
 
-      if (!activeCount && !completedCount)
+      if (activeCount + completedCount != groupTasks.length)
         inactiveTaskWorkflows.push(this.taskWorkflows[i]);
-      else if (completedCount == groupTasks?.length) {
-        completeTaskWorkflows.push(this.taskWorkflows[i]);
-      } else {
-        if (completedCount) completeTaskWorkflows.push(this.taskWorkflows[i]);
-        activeTaskWorkflows.push(this.taskWorkflows[i]);
-      }
+      if (completedCount) completeTaskWorkflows.push(this.taskWorkflows[i]);
+      if (activeCount) activeTaskWorkflows.push(this.taskWorkflows[i]);
     }
     this.inactiveTaskWorkflows = inactiveTaskWorkflows;
     this.completeTaskWorkflows = completeTaskWorkflows;
@@ -338,7 +334,6 @@ export class CkMonitorComponent implements OnInit, OnDestroy {
     const groupTasksTableFormat: MonitorData[] = [];
     if (groupTasks) {
       for (let i = 0; i < groupTasks.length; i++) {
-        console.log(i);
         if (groupTasks[i].groupTask.status == status) {
           const groupMembers: string[] = [];
           for (let j = 0; j < groupTasks[i].group.members.length; j++) {
@@ -365,7 +360,6 @@ export class CkMonitorComponent implements OnInit, OnDestroy {
     this.runningTaskTableData = new MatTableDataSource<MonitorData>(
       groupTasksTableFormat
     );
-    console.log(this.runningTaskTableData);
   }
 
   async activateGroupTask(_group: MonitorData) {
@@ -377,6 +371,9 @@ export class CkMonitorComponent implements OnInit, OnDestroy {
     this.runningTaskTableData.data = this.runningTaskTableData.data.filter(
       (data) => data.groupTaskID != _group.groupTaskID
     );
+    if (!this.runningTaskTableData.data.length) {
+      this.runningTask = null;
+    }
   }
 
   async completeGroupTask(_group: MonitorData) {
@@ -388,6 +385,9 @@ export class CkMonitorComponent implements OnInit, OnDestroy {
     this.runningTaskTableData.data = this.runningTaskTableData.data.filter(
       (data) => data.groupTaskID != _group.groupTaskID
     );
+    if (!this.runningTaskTableData.data.length) {
+      this.runningTask = null;
+    }
   }
 
   close(): void {

--- a/frontend/src/app/models/workflow.ts
+++ b/frontend/src/app/models/workflow.ts
@@ -84,7 +84,7 @@ export class DistributionWorkflow extends Workflow {
 
 export class TaskWorkflow extends Workflow {
   prompt: string;
-
+  // complete?: boolean;
   requiredActions: TaskAction[];
   assignedGroups: string[];
 }

--- a/frontend/src/app/models/workflow.ts
+++ b/frontend/src/app/models/workflow.ts
@@ -84,7 +84,6 @@ export class DistributionWorkflow extends Workflow {
 
 export class TaskWorkflow extends Workflow {
   prompt: string;
-  // complete?: boolean;
   requiredActions: TaskAction[];
   assignedGroups: string[];
 }

--- a/frontend/src/app/services/workflow.service.ts
+++ b/frontend/src/app/services/workflow.service.ts
@@ -158,4 +158,10 @@ export class WorkflowService {
       .post<GroupTask>(`workflows/task/groupTask/${groupTaskID}/complete`, {})
       .toPromise();
   }
+
+  markGroupTaskActive(groupTaskID: string): Promise<GroupTask> {
+    return this.http
+      .post<GroupTask>(`workflows/task/groupTask/${groupTaskID}/active`, {})
+      .toPromise();
+  }
 }

--- a/frontend/src/app/services/workflow.service.ts
+++ b/frontend/src/app/services/workflow.service.ts
@@ -4,6 +4,7 @@ import {
   DistributionWorkflow,
   GroupTask,
   GroupTaskEntity,
+  GroupTaskStatus,
   GroupTaskType,
   TaskWorkflow,
   Workflow,
@@ -155,13 +156,17 @@ export class WorkflowService {
 
   markGroupTaskComplete(groupTaskID: string): Promise<GroupTask> {
     return this.http
-      .post<GroupTask>(`workflows/task/groupTask/${groupTaskID}/complete`, {})
+      .post<GroupTask>(`workflows/task/groupTask/${groupTaskID}/status`, {
+        status: GroupTaskStatus.COMPLETE,
+      })
       .toPromise();
   }
 
   markGroupTaskActive(groupTaskID: string): Promise<GroupTask> {
     return this.http
-      .post<GroupTask>(`workflows/task/groupTask/${groupTaskID}/active`, {})
+      .post<GroupTask>(`workflows/task/groupTask/${groupTaskID}/status`, {
+        status: GroupTaskStatus.ACTIVE,
+      })
       .toPromise();
   }
 }


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- From the CK-Monitor, teachers can now Cancel Active tasks, which will move the specified group into the "Completed Task" area
- Likewise, Group Tasks in the "Completed task" area can be activated and will move to the "Active Task" area
- No additional changes for Inactive tasks

Closes #467 
