### PR TITLE
(FIX): Redirect to initial URL upon login

### DIFF
--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -109,7 +109,9 @@ export const getParamMap = (params: string): Map<string, string> => {
   const paramMap = new Map<string, string>();
   const keyValuePairs = params.split('&');
   keyValuePairs.forEach((keyValuePair) => {
-    const [key, value] = keyValuePair.split('=');
+    // Get everything before the = as the key and everything after the = as the value
+    const splitResult = keyValuePair.split(/=(.*)/);
+    const [key, value] = splitResult;
     paramMap.set(key, value);
   });
   return paramMap;

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -17,7 +17,9 @@ export class LoginComponent {
   invalidCredentials = false;
 
   constructor(private userService: UserService, private router: Router) {
-    if (this.userService.loggedIn) this.router.navigate(['/dashboard']);
+    if (this.userService.loggedIn) {
+      this.router.navigate(['/dashboard']);
+    }
   }
 
   onLogin() {
@@ -28,7 +30,21 @@ export class LoginComponent {
         const redirectUrl = this.userService.redirectUrl;
         this.userService.redirectUrl = null;
         if (redirectUrl) {
-          this.router.navigate([redirectUrl]);
+          // Parse query parameters (if they exist)
+          const searchParams =
+            redirectUrl.indexOf('?') != -1
+              ? new URLSearchParams(
+                  redirectUrl.substring(redirectUrl.indexOf('?'))
+                )
+              : [];
+
+          this.router.navigate([`${redirectUrl.split('?')[0]}`], {
+            queryParams: [...searchParams].reduce((o, [key, value]) => {
+              o[key] = value;
+              return o;
+            }, {}),
+            queryParamsHandling: 'merge',
+          });
         } else {
           this.router.navigate(['dashboard']);
         }

--- a/frontend/src/app/guards/auth.guard.ts
+++ b/frontend/src/app/guards/auth.guard.ts
@@ -17,15 +17,20 @@ export class AuthGuard implements CanActivate {
     public ngZone: NgZone
   ) {}
 
-  canActivate(_next: ActivatedRouteSnapshot, _state: RouterStateSnapshot) {
+  async canActivate(
+    _next: ActivatedRouteSnapshot,
+    _state: RouterStateSnapshot
+  ) {
     if (this.userService.loggedIn) {
       return true;
     }
     this.userService.redirectUrl = _state.url;
 
-    this.router.navigate(['/login'], {
-      state: { code: 403, message: 'Forbidden! Please sign in' },
-    });
+    if (await !this.userService.isSsoEnabled()) {
+      this.router.navigate(['/login'], {
+        state: { code: 403, message: 'Forbidden! Please sign in' },
+      });
+    }
     return false;
   }
 }

--- a/frontend/src/app/guards/board.guard.ts
+++ b/frontend/src/app/guards/board.guard.ts
@@ -29,6 +29,10 @@ export class BoardGuard implements CanActivate {
     next: ActivatedRouteSnapshot,
     _state: RouterStateSnapshot
   ): Promise<boolean> {
+    if (!this.userService.loggedIn) {
+      return false;
+    }
+
     const boardID = next.params.boardID;
 
     if (boardID) {

--- a/frontend/src/app/guards/project.guard.ts
+++ b/frontend/src/app/guards/project.guard.ts
@@ -32,6 +32,10 @@ export class ProjectGuard implements CanActivate {
     next: ActivatedRouteSnapshot,
     _state: RouterStateSnapshot
   ): Promise<boolean> {
+    if (!this.userService.loggedIn) {
+      return false;
+    }
+
     const projectID = next.params.projectID;
 
     const isValidProject = await this.isValidProject(projectID);


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- If a user is not logged into CK-Board and tries to navigate to any url (including embedded urls), they will be redirected to the login page, and after they login, they will be redirected to the URL they originally wanted to go to (if they are authorized to)
- Tested for all embeded URL's (todo, ck-monitor, ck-workspace, board)

- Weird bug for board embeddable URLs was occured when it was running the AuthGuard, it would simultaneously run the BoardGoard and ProjectGuard as well. The AuthGuard would redirect to /login momentarily, but would have a race condition with the BoardGuard, which would then send it to /error since you aren't logged in and can't access API. To quickly remedy this, i added a if statement in BoardGuard and ProjectGuard, to see if the user is logged in, if not it would return false, and the AuthGuard would reroute to /login properly.

Bug:
- To redirect to URL with queryParams, we need to parse them and send it as a separate object to `this.router.navigate`, which it didn't do before.

@JoelWiebe  Could you test this out and see if it works as we want when used in SCORE? It works fine when using it just with CK-Board, so theoretically it should do in SCORE as well.

Closes #505 

