### PR TITLE
(FIX): Posts can be downloaded from List and Bucket View error-free

### DIFF
--- a/backend/src/repository/dalPost.ts
+++ b/backend/src/repository/dalPost.ts
@@ -97,11 +97,11 @@ export const removeByBoard = async (boardID: string) => {
 
 export const update = async (id: string, post: Partial<PostModel>) => {
   try {
-    const setPost: any = flatten(post);
-
-    const updatedPost = await Post.findOneAndUpdate({ postID: id }, setPost, {
-      new: true,
-    });
+    const updatedPost = await Post.findOneAndUpdate(
+      { postID: id },
+      { $set: post },
+      { new: true }
+    );
     return updatedPost;
   } catch (err) {
     throw new Error(JSON.stringify(err, null, ' '));


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Previously we were trying to update posts by passing the flattened version of the post to the `$set` operator, but the `$set` operation doesnt work with dot notation, so this would be the cause for error:

    ```typescript
    {
      '$set': {
        type: 'BOARD',
        title: 'testing bug',
        desc: '',
        tags: [],
        multipleChoice: undefined,
        'displayAttributes.position.left': 720,
        'displayAttributes.position.top': 219,
        'displayAttributes.lock': false
      }
    }
    ```
- If we simply pass the fields of the Post that we want to modify to the `$set` operator directly, it will update them successfully, and the post will be downloaded
- Tested for both List and Bucket Views


Closes #507 
