### PR TITLE
(FEAT): Implementation Generative task workflow completed

### DIFF
--- a/backend/src/agents/workflow.agent.ts
+++ b/backend/src/agents/workflow.agent.ts
@@ -13,6 +13,7 @@ import {
   WorkflowModel,
   DistributionWorkflowType,
   Container,
+  TaskWorkflowType,
 } from '../models/Workflow';
 import dalBucket from '../repository/dalBucket';
 import dalPost from '../repository/dalPost';
@@ -97,7 +98,6 @@ class WorkflowManager {
   async runTaskWorkflow(taskWorkflow: TaskWorkflowModel) {
     const { source, assignedGroups } = taskWorkflow;
     let sourcePosts;
-
     if (source.type == ContainerType.BOARD) {
       sourcePosts = await dalPost.getByBoard(source.id);
       sourcePosts = sourcePosts.map((p) => p.postID);
@@ -111,12 +111,17 @@ class WorkflowManager {
       sourcePosts.length / taskWorkflow.assignedGroups.length
     );
 
+    // if (taskWorkflow?.type === TaskWorkflowType.GENERATION) sourcePosts = [];
     const commentAction = taskWorkflow.requiredActions.find(
       (a) => a.type == TaskActionType.COMMENT
     );
     const tagAction = taskWorkflow.requiredActions.find(
       (a) => a.type == TaskActionType.TAG
     );
+    const createPostAction = taskWorkflow.requiredActions.find(
+      (a) => a.type == TaskActionType.CREATE_POST
+    );
+
     const actions: TaskAction[] = [];
     if (commentAction)
       actions.push({
@@ -132,7 +137,10 @@ class WorkflowManager {
     if (assignedGroups.length > 0) {
       for (let i = 0; i < assignedGroups.length; i++) {
         const assignedGroup = assignedGroups[i];
-        const posts = split[i] ?? [];
+        const posts =
+          taskWorkflow?.type === TaskWorkflowType.GENERATION
+            ? []
+            : split[i] ?? [];
 
         const progress: Map<string, TaskAction[]> = new Map<
           string,

--- a/backend/src/api/workflows.ts
+++ b/backend/src/api/workflows.ts
@@ -216,7 +216,7 @@ router.delete('/task/:id', async (req, res) => {
 router.get('/task/:workflowID/groupTask/group/:groupID', async (req, res) => {
   const { workflowID, groupID } = req.params;
   const representation = req.query.representation as string;
-  console.log('zdsfg');
+
   const groupTask = await dalGroupTask.getByWorkflowGroup(workflowID, groupID);
   if (!groupTask) return res.status(404).end('No group task found.');
 

--- a/backend/src/api/workflows.ts
+++ b/backend/src/api/workflows.ts
@@ -216,7 +216,7 @@ router.delete('/task/:id', async (req, res) => {
 router.get('/task/:workflowID/groupTask/group/:groupID', async (req, res) => {
   const { workflowID, groupID } = req.params;
   const representation = req.query.representation as string;
-
+  console.log('zdsfg');
   const groupTask = await dalGroupTask.getByWorkflowGroup(workflowID, groupID);
   if (!groupTask) return res.status(404).end('No group task found.');
 
@@ -268,12 +268,13 @@ router.get('/task/groupTask/board/:boardID/user/:userID', async (req, res) => {
  */
 router.post('/task/groupTask/:groupTaskID', async (req, res) => {
   const { groupTaskID } = req.params;
-  const { actions, posts, status } = req.body;
+  const { actions, posts, status, progress } = req.body;
 
   const update: Partial<GroupTaskModel> = Object.assign(
     {},
     actions === null ? null : { actions },
     posts === null ? null : { posts },
+    progress === null ? null : { progress },
     status === null ? null : { status }
   );
 

--- a/backend/src/models/Workflow.ts
+++ b/backend/src/models/Workflow.ts
@@ -8,6 +8,12 @@ import {
 export enum WorkflowType {
   DISTRIBUTION = 'DISTRIBUTION',
   TASK = 'TASK',
+  GENERATION = 'GENERATION',
+}
+
+export enum TaskWorkflowType {
+  PEER_REVIEW = 'PEER_REVIEW',
+  GENERATION = 'GENERATION',
 }
 
 export enum DistributionWorkflowType {
@@ -24,6 +30,7 @@ export enum ContainerType {
 export enum TaskActionType {
   COMMENT = 'COMMENT',
   TAG = 'TAG',
+  CREATE_POST = 'CREATE_POST',
 }
 
 export class DistributionWorkflowTypeModel {
@@ -91,6 +98,9 @@ export class TaskWorkflowModel extends WorkflowModel {
 
   @prop({ required: true })
   public assignedGroups!: string[];
+
+  @prop({ enum: TaskWorkflowType, type: String, required: false })
+  public type?: string;
 }
 
 export const Workflow = getModelForClass(WorkflowModel);

--- a/backend/src/socket/events/workflow.events.ts
+++ b/backend/src/socket/events/workflow.events.ts
@@ -5,6 +5,8 @@ import {
   TaskWorkflowModel,
 } from '../../models/Workflow';
 import { SocketPayload } from '../types/event.types';
+import { GroupTaskModel } from '../../models/GroupTask';
+import { GroupModel } from '../../models/Group';
 
 class WorkflowRunDistribution {
   static type: SocketEvent = SocketEvent.WORKFLOW_RUN_DISTRIBUTION;
@@ -42,6 +44,54 @@ class WorkflowRunTask {
   }
 }
 
-const workflowEvents = [WorkflowRunDistribution, WorkflowRunTask];
+class WorkflowUpdate {
+  static type: SocketEvent = SocketEvent.WORKFLOW_PROGRESS_UPDATE;
+
+  static async handleEvent(
+    input: SocketPayload<
+      [
+        {
+          groupTask: GroupTaskModel;
+          workflow: TaskWorkflowModel;
+          group: GroupModel;
+        }
+      ]
+    >
+  ): Promise<
+    | [
+        {
+          groupTask: GroupTaskModel;
+          workflow: TaskWorkflowModel;
+          group: GroupModel;
+        }
+      ]
+    | null
+  > {
+    return input.eventData;
+  }
+
+  static async handleResult(
+    io: Server,
+    socket: Socket,
+    result:
+      | [
+          {
+            groupTask: GroupTaskModel;
+            workflow: TaskWorkflowModel;
+            group: GroupModel;
+          }
+        ]
+      | null
+  ) {
+    console.log('hereeeeeeee');
+    socket.to(socket.data.room).emit(this.type, result);
+  }
+}
+
+const workflowEvents = [
+  WorkflowRunDistribution,
+  WorkflowRunTask,
+  WorkflowUpdate,
+];
 
 export default workflowEvents;

--- a/frontend/src/app/components/add-post-modal/add-post.component.ts
+++ b/frontend/src/app/components/add-post-modal/add-post.component.ts
@@ -36,6 +36,7 @@ export interface AddPostDialog {
   spawnPosition: { left: number; top: number };
   onComplete?: (post: any) => any;
   editingPost?: Post | undefined;
+  disableCreation?: boolean;
 }
 
 @Component({
@@ -237,6 +238,20 @@ export class AddPostComponent {
     };
   }
 
+  getPartialPost(): Partial<Post> {
+    return {
+      postID: generateUniqueID(),
+      userID: this.user.userID,
+      author: this.user.username,
+      contentType: this.contentType,
+      multipleChoice: this.multipleChoiceOptions,
+      title: this.title,
+      desc: this.message,
+      tags: this.tags,
+      displayAttributes: null,
+    };
+  }
+
   async addPost() {
     const post = this.getBoardPost();
     await this.canvasService.createPost(post);
@@ -306,6 +321,14 @@ export class AddPostComponent {
 
   async handleDialogSubmit() {
     let post: Post;
+    if (this.data?.disableCreation) {
+      const _post = this.getPartialPost();
+      if (this.data.onComplete) {
+        this.data.onComplete(_post);
+      }
+      this.dialogRef.close();
+      return;
+    }
 
     if (this.data.type == PostType.BUCKET && this.data.bucket) {
       post = await this.addBucketPost();

--- a/frontend/src/app/components/ck-workspace/ck-workspace.component.html
+++ b/frontend/src/app/components/ck-workspace/ck-workspace.component.html
@@ -98,11 +98,26 @@
         No task selected!
       </div>
       <mat-spinner class="spinner" *ngIf="loading"></mat-spinner>
+      <div *ngIf="!loading && runningGroupTask && runningGroupTask.workflow.type === TaskWorkflowType.GENERATION && !taskSubmittable(runningGroupTask) && runningGroupTask.groupTask.status !== GroupTaskStatus.COMPLETE" class="heading workflow-create-post">
+        <button
+          mat-raised-button
+          matTooltip="Create Post"
+          (click)="addPost()"
+          style="margin: 0; padding: 0; line-height: inherit; height: inherit"
+        >
+          <mat-icon>add</mat-icon>
+        </button>
+      </div>
       <div *ngIf="!loading" style="display: flex; flex-direction: row;">
-        <div class="heading no-posts" *ngIf="runningGroupTask && (!posts || posts.length === 0)">
+        <div class="heading no-posts" *ngIf="runningGroupTask && runningGroupTask.workflow.type !== TaskWorkflowType.GENERATION && (!posts || posts.length === 0)">
           No posts to review!
         </div>
-        <swiper [effect]="'cards'" [grabCursor]="true" class="mySwiper" *ngIf="runningGroupTask && posts && posts.length > 0">
+        <div class="heading no-posts" *ngIf="runningGroupTask && runningGroupTask.workflow.type === TaskWorkflowType.GENERATION && (!posts || posts.length === 0)">
+          Create a Post!
+        </div>
+
+        <!-- Draft post slider -->
+        <swiper [effect]="'cards'" [grabCursor]="true" class="mySwiper" *ngIf="runningGroupTask && !showSubmittedPosts && posts && posts.length > 0">
           <ng-template swiperSlide *ngFor="let htmlPost of posts">
             <div (click)="$event.stopPropagation();" style="display: flex; flex-direction: column; gap: 10px;">
               <app-html-post 
@@ -118,6 +133,23 @@
             </div>
           </ng-template>
         </swiper>
+        <!-- Submitted Post Slider -->
+        <swiper [effect]="'cards'" [grabCursor]="true" class="mySwiper" *ngIf="runningGroupTask && showSubmittedPosts && submittedPosts && submittedPosts.length > 0">
+          <ng-template swiperSlide *ngFor="let htmlPost of submittedPosts">
+            <div (click)="$event.stopPropagation();" style="display: flex; flex-direction: column; gap: 10px;">
+              <app-html-post 
+                (click)="$event.stopPropagation();" 
+                [post]="htmlPost" [disableDownload]="true" 
+                style="width: 360px; height: 100%;">
+              </app-html-post>
+              <div style="display: flex; flex-direction: row;">
+                <button (click)="swiper.swiperRef.slidePrev()" mat-raised-button color="accent" style="width: 30%; margin: 0px 5px;">Previous</button>
+                <button mat-raised-button color="primary"  style="width: 30%; margin: 0px 5px;">Submitted!</button>
+                <button (click)="swiper.swiperRef.slideNext()" mat-raised-button color="accent" style="width: 30%; margin: 0px 5px;">Next</button>
+              </div>
+            </div>
+          </ng-template>
+        </swiper>
         <div *ngIf="runningGroupTask">
           <mat-card class="example-card" style="width: 350px; margin: 10px auto">
             <mat-card-title>{{runningGroupTask.group.name}}: {{runningGroupTask.workflow.name}}</mat-card-title>
@@ -128,6 +160,7 @@
                 <ul style="list-style-position: inside; padding-left: 0; font-weight: bold;">
                   <li *ngIf="hasCommentRequirement(runningGroupTask)">Comment on each post at least once!</li>
                   <li *ngIf="hasTagRequirement(runningGroupTask)">Tag each post at least once!</li>
+                  <li *ngIf="hasCreatePostRequirement(runningGroupTask)">Create {{numberOfPosts(runningGroupTask)}} posts</li>
                 </ul>
               </section>
             </mat-card-content>

--- a/frontend/src/app/components/ck-workspace/ck-workspace.component.html
+++ b/frontend/src/app/components/ck-workspace/ck-workspace.component.html
@@ -128,7 +128,7 @@
               </app-html-post>
               <div style="display: flex; flex-direction: row;">
                 <button (click)="swiper.swiperRef.slidePrev()" mat-raised-button color="accent" style="width: 30%; margin: 0px 5px;">Previous</button>
-                <button (click)="submitPost(htmlPost)" mat-raised-button color="primary" [disabled]="runningGroupTask.groupTask.status === GroupTaskStatus.COMPLETE || !postSubmittable(htmlPost)" style="width: 30%; margin: 0px 5px;">Submit</button>
+                <button (click)="submitPost(htmlPost)" mat-raised-button color="primary" [disabled]="runningGroupTask.groupTask.status === GroupTaskStatus.COMPLETE || !postSubmittable(htmlPost) || runningGroupTask.workflow.type === TaskWorkflowType.GENERATION" style="width: 30%; margin: 0px 5px;">Submit</button>
                 <button (click)="swiper.swiperRef.slideNext()" mat-raised-button color="accent" style="width: 30%; margin: 0px 5px;">Next</button>
               </div>
             </div>

--- a/frontend/src/app/components/ck-workspace/ck-workspace.component.scss
+++ b/frontend/src/app/components/ck-workspace/ck-workspace.component.scss
@@ -99,3 +99,13 @@ mat-sidenav-content {
 
   min-height: 80vh;
 }
+.workflow-create-post{
+  width:100%;
+  top: 0;
+  text-align: center;
+}
+.workflow-create-post > button{
+  margin: 20px;
+  width:100%;
+  background-color: #6c63ff;
+}

--- a/frontend/src/app/components/ck-workspace/ck-workspace.component.ts
+++ b/frontend/src/app/components/ck-workspace/ck-workspace.component.ts
@@ -183,7 +183,6 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
     } else {
       postIDs = postIDs.concat(groupTask.groupTask.posts);
     }
-    console.log(postIDs);
     const posts = await this.postService.getAll(postIDs);
     this.posts = await this.converters.toHTMLPosts(posts);
     this.members = await this.userService.getMultipleByIds(
@@ -360,16 +359,12 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
             }
           );
 
-          console.log(t);
-          console.log(this.runningGroupTask);
           this.currentGroupProgress = this._calcGroupProgress(
             this.runningGroupTask
           );
           this.averageGroupProgress = await this._calcAverageProgress(
             this.runningGroupTask
           );
-          console.log(this.currentGroupProgress);
-          console.log(this.averageGroupProgress);
           this.socketService.emit(SocketEvent.WORKFLOW_PROGRESS_UPDATE, [
             this.runningGroupTask.groupTask,
           ]);
@@ -488,7 +483,6 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
         const found = this.posts.find(
           (p) => p.post.postID == result.comment.postID
         );
-        console.log('comment adde');
         if (found) {
           found.comments += 1;
         }
@@ -507,7 +501,6 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
     this.listeners.push(
       this.socketService.listen(SocketEvent.POST_TAG_ADD, ({ post }) => {
         const found = this.posts.find((p) => p.post.postID == post.postID);
-        console.log('tag adde');
         if (found) {
           found.post = post;
         }
@@ -516,7 +509,6 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
     this.listeners.push(
       this.socketService.listen(SocketEvent.POST_TAG_REMOVE, ({ post }) => {
         const found = this.posts.find((p) => p.post.postID == post.postID);
-        console.log('tag remove');
         if (found) {
           found.post = post;
         }
@@ -555,14 +547,12 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
   }
 
   private _calcGroupProgress(task: ExpandedGroupTask | null): number {
-    console.log(task);
     if (!task) return 0;
     // get all posts' progress
     const values = Object.keys(task.groupTask.progress).map(function (key) {
       return task.groupTask.progress[key];
     });
 
-    console.log(values);
     // sum all amountRequired for each action per post
     // i.e. Post A (1 tag req, 1 comment req) + Post B (1 tag req, 0 comments required)
     let remaining = values.reduce(
@@ -586,8 +576,6 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
         (a) => a.type === TaskActionType.CREATE_POST
       )[0].amountRequired;
       const actionPerPost = total;
-      console.log(createPosts);
-      console.log(total);
       if (total) total = total * createPosts + createPosts;
       else total = createPosts;
 
@@ -596,8 +584,6 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
     } else {
       total *= values.length;
     }
-    console.log(total);
-    console.log(remaining);
     return ((total - remaining) / total) * 100;
   }
 

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.html
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.html
@@ -61,7 +61,8 @@
     <mat-tab label="Create Workflow">
       <mat-radio-group [(ngModel)]="workflowType">
         <mat-radio-button style="margin-top: 20px;" [checked]="true" [value]="WorkflowType.DISTRIBUTION">Distribution Workflow</mat-radio-button>
-        <mat-radio-button style="margin-top: 20px;" [checked]="false" [value]="WorkflowType.TASK">Task Workflow</mat-radio-button>
+        <mat-radio-button style="margin-top: 20px;" [checked]="false" [value]="WorkflowType.GENERATION">Generation Task Workflow</mat-radio-button>
+        <mat-radio-button style="margin-top: 20px;" [checked]="false" [value]="WorkflowType.TASK">Peer Review Workflow</mat-radio-button>
       </mat-radio-group>
       <div *ngIf="workflowType === WorkflowType.DISTRIBUTION">
         <mat-form-field appearance="fill" style="margin-top: 10px;">
@@ -201,6 +202,57 @@
           </div>
         </section>
       </div>
+      <div *ngIf="workflowType === WorkflowType.GENERATION">
+        <mat-form-field appearance="fill" style="margin-top: 10px;">
+          <mat-label>Workflow Name</mat-label>
+          <input [formControl]="workflowNameFormControl" [errorStateMatcher]="matcher" matInput [(ngModel)]="workflowName">
+          <mat-error *ngIf="workflowNameFormControl.hasError('required')">Workflow name required!</mat-error>
+        </mat-form-field>
+        <div class="source-destination">
+          <mat-form-field appearance="fill" style="font-size: 14px !important">
+            <mat-label>Destination</mat-label>
+            <mat-select [(ngModel)]="taskDestination" [formControl]="destinationFormControl" [errorStateMatcher]="matcher">
+              <mat-option *ngFor="let option of destOptions" [value]="option">{{ option.name }}</mat-option>
+              <mat-option [value]="board" >{{ board.name }}</mat-option>
+            </mat-select>
+            <mat-error *ngIf="destinationFormControl.hasError('required')">Destination required!</mat-error>
+          </mat-form-field>
+        </div>
+        <section>
+          <div style="display: flex; flex-direction: row; gap: 10px;">
+            <mat-form-field appearance="fill" style="font-size: 14px !important">
+              <mat-label>Assigned Groups</mat-label>
+              <mat-select [(ngModel)]="assignedGroups" [formControl]="groupsFormControl" [errorStateMatcher]="matcher" multiple>
+                <mat-option *ngFor="let option of groupOptions" [value]="option">{{ option.name }}</mat-option>
+              </mat-select>
+              <mat-error *ngIf="groupsFormControl.hasError('required')">At least one group required!</mat-error>
+            </mat-form-field>
+          </div>
+        </section>
+        <section>
+          <mat-form-field appearance="fill" style="width: 100%;">
+            <mat-label>Student Prompt</mat-label>
+            <textarea matInput [formControl]="promptFormControl" [errorStateMatcher]="matcher" [(ngModel)]="prompt" placeholder="Please use tags to categorize each idea (e.g., financial, transportation, technology)"></textarea>
+            <mat-error *ngIf="promptFormControl.hasError('required')">Prompt is required!</mat-error>
+          </mat-form-field>
+        </section>
+        <section>
+          <h4 style="font-weight: bold">
+            Workflow Actions:
+          </h4>
+          <div>
+            <mat-label>Number of Posts to generate:</mat-label>
+            <mat-slider
+              class="slider"
+              min="1"
+              max="10"
+              step="1"
+              thumbLabel
+              [(ngModel)]="postGeneration"
+            ></mat-slider>
+          </div>
+        </section>
+      </div>
     </mat-tab>
     <mat-tab label="Manage Workflows"> 
       <h3 *ngIf="!workflows || workflows.length === 0" style="color: grey; text-align: center;">No workflows created!</h3>
@@ -213,8 +265,9 @@
             </mat-panel-title>
             <mat-panel-description>
               <mat-chip-list>
-                <mat-chip color="primary" selected *ngIf="workflow.distributionWorkflowType">Distribution Workflow</mat-chip>
-                <mat-chip color="primary" selected *ngIf="workflow.requiredActions">Task Workflow</mat-chip>
+                <mat-chip color="primary" selected *ngIf="workflow.distributionWorkflowType">Distribution</mat-chip>
+                <mat-chip color="primary" selected *ngIf="workflow.requiredActions && workflow.type != taskWorkflowType.GENERATION">Peer Review</mat-chip>
+                <mat-chip color="primary" selected *ngIf="workflow.type == taskWorkflowType.GENERATION">Generation</mat-chip>
               </mat-chip-list> 
               <div>
                 <button mat-icon-button [disabled]="workflow.active" (click)="runWorkflow($event, workflow)">
@@ -277,11 +330,19 @@
               </h4>
             </div>
           </div>
-          <div *ngIf="workflow.requiredActions">
+          <div *ngIf="workflow.requiredActions && workflow.type != taskWorkflowType.GENERATION">
             <h4>
               Required Actions:
               <mat-chip color="accent" selected style="margin: 0 5px" *ngFor="let action of workflow.requiredActions">
                 1 {{action.type.toLowerCase()}} per post
+              </mat-chip>
+            </h4>
+          </div>
+          <div *ngIf="workflow.type == taskWorkflowType.GENERATION">
+            <h4>
+              Required Actions:
+              <mat-chip color="accent" selected style="margin: 0 5px" *ngFor="let action of workflow.requiredActions">
+                Generate {{action.amountRequired.toString()}} post(s)
               </mat-chip>
             </h4>
           </div>
@@ -298,6 +359,28 @@
 <div mat-dialog-actions>
   <button mat-button (click)="onNoClick()">Close</button>
   <button mat-button *ngIf="selected.value === 0" [disabled]="!_validBucketForm()" (click)="createBucket()">Create Bucket!</button>
-  <button mat-button *ngIf="selected.value === 1 && workflowType === WorkflowType.DISTRIBUTION" [disabled]="!_validDistributionWorkflow()" (click)="createDistributionWorkflow()">Create Distribution Workflow!</button>
-  <button mat-button *ngIf="selected.value === 1 && workflowType === WorkflowType.TASK" [disabled]="!_validTaskWorkflow()" (click)="createTaskWorkflow()">Create Task Workflow!</button>
+  <button 
+    mat-button 
+    *ngIf="selected.value === 1 && workflowType === WorkflowType.DISTRIBUTION" 
+    [disabled]="!_validDistributionWorkflow()" 
+    (click)="createDistributionWorkflow()"
+  >
+    Create Distribution Workflow!
+  </button>
+  <button 
+    mat-button 
+    *ngIf="selected.value === 1 && workflowType === WorkflowType.TASK" 
+    [disabled]="!_validPeerReviewWorkflow()" 
+    (click)="createPeerReviewWorkflow()"
+    >
+      Create Peer Review Workflow!
+  </button>
+  <button 
+    mat-button 
+    *ngIf="selected.value === 1 && workflowType === WorkflowType.GENERATION" 
+    [disabled]="!_validGenerationTaskWorkflow()" 
+    (click)="createGenerationTaskWorkflow()"
+    >
+      Create Generation Task Workflow!
+  </button>
 </div>

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.html
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.html
@@ -251,6 +251,14 @@
               [(ngModel)]="postGeneration"
             ></mat-slider>
           </div>
+          <div style="display: flex; flex-direction: column; gap: 10px;">
+            <mat-checkbox [(ngModel)]="commentsRequired">
+              Require minimum 1 comment per post
+            </mat-checkbox>
+            <mat-checkbox [(ngModel)]="tagsRequired">
+              Require minimum 1 tag per post
+            </mat-checkbox>
+          </div>
         </section>
       </div>
     </mat-tab>

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
@@ -224,7 +224,6 @@ export class CreateWorkflowModalComponent implements OnInit {
 
   createGenerationTaskWorkflow(): void {
     if (!this._validGenerationTaskWorkflow()) return;
-    console.log(this.postGeneration);
     const workflow: TaskWorkflow = this._assembleGenerationTaskWorkflow();
     this.workflowService.createTask(workflow).then(async () => {
       await this.loadWorkflows();

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
@@ -432,6 +432,16 @@ export class CreateWorkflowModalComponent implements OnInit {
         type: TaskActionType.CREATE_POST,
         amountRequired: this.postGeneration,
       });
+    if (this.commentsRequired)
+      actions.push({
+        type: TaskActionType.COMMENT,
+        amountRequired: 1,
+      });
+    if (this.tagsRequired)
+      actions.push({
+        type: TaskActionType.TAG,
+        amountRequired: 1,
+      });
 
     const workflow: TaskWorkflow = {
       workflowID: workflowID,

--- a/frontend/src/app/models/workflow.ts
+++ b/frontend/src/app/models/workflow.ts
@@ -25,11 +25,18 @@ export class Container {
 export enum WorkflowType {
   DISTRIBUTION = 'DISTRIBUTION',
   TASK = 'TASK',
+  GENERATION = 'GENERATION',
+}
+
+export enum TaskWorkflowType {
+  PEER_REVIEW = 'PEER_REVIEW',
+  GENERATION = 'GENERATION',
 }
 
 export enum TaskActionType {
   COMMENT = 'COMMENT',
   TAG = 'TAG',
+  CREATE_POST = 'CREATE_POST',
 }
 
 export enum GroupTaskStatus {
@@ -86,6 +93,7 @@ export class TaskWorkflow extends Workflow {
   prompt: string;
   requiredActions: TaskAction[];
   assignedGroups: string[];
+  type?: TaskWorkflowType;
 }
 
 const workflows = {

--- a/frontend/src/app/services/canvas.service.ts
+++ b/frontend/src/app/services/canvas.service.ts
@@ -170,11 +170,6 @@ export class CanvasService {
     const tags = [...post.tags, tag];
     const update: Partial<Post> = { tags };
 
-    // if (!post.displayAttributes) {
-    //   console.log('here');
-    //   return await this.postService.update(post.postID, { tags: tags });
-    // }
-
     if (tag.specialAttributes) {
       update.displayAttributes = this.fabricUtils.applyTagFeatures(
         post.postID,
@@ -182,7 +177,6 @@ export class CanvasService {
       );
     }
     const savedPost = await this.postService.update(post.postID, update);
-    // console.log('here');
     this.socketService.emit(SocketEvent.POST_TAG_ADD, {
       tag,
       post: savedPost,

--- a/frontend/src/app/services/canvas.service.ts
+++ b/frontend/src/app/services/canvas.service.ts
@@ -170,9 +170,10 @@ export class CanvasService {
     const tags = [...post.tags, tag];
     const update: Partial<Post> = { tags };
 
-    if (!post.displayAttributes) {
-      return await this.postService.update(post.postID, { tags: tags });
-    }
+    // if (!post.displayAttributes) {
+    //   console.log('here');
+    //   return await this.postService.update(post.postID, { tags: tags });
+    // }
 
     if (tag.specialAttributes) {
       update.displayAttributes = this.fabricUtils.applyTagFeatures(
@@ -181,7 +182,7 @@ export class CanvasService {
       );
     }
     const savedPost = await this.postService.update(post.postID, update);
-
+    // console.log('here');
     this.socketService.emit(SocketEvent.POST_TAG_ADD, {
       tag,
       post: savedPost,

--- a/frontend/src/app/services/groupTask.service.ts
+++ b/frontend/src/app/services/groupTask.service.ts
@@ -21,7 +21,9 @@ export class GroupTaskService {
 
   getGroupTask(groupID: string, workflowID: string): Promise<GroupTask> {
     return this.http
-      .get<GroupTask>('workflows/' + workflowID + '/task/group/' + groupID)
+      .get<GroupTask>(
+        'workflows/task/' + workflowID + '/groupTask/group/' + groupID
+      )
       .toPromise();
   }
 


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Generative Task workflow implemented
- Groups now can be given the task of creating a set amount of posts [1, 10] collectively as a group
- Along with post creation, groups can also be given the task of commenting and/or tagging each of the posts they create
    - Small caveat with this: The "Submit" button for the generative task workflow is disabled (it removes the posts from the groupTask, causing progress to decrease, which is not what we want). However, once all tasks are complete the "Mark as Complete" button is enabled and the Task can be marked as completed.
- Used sockets to update group progress in real time, hence post show up in CK workspace when other members of the group create a post from their end of CK workspace
- Destinations of where the posts are created can be set as buckets in the current board, or any other board in the project


Closes #356 
