### PR TITLE
fix: disable todo monitor "Mark as Done" option

### DIFF
--- a/frontend/src/app/components/todo-item-card-modal/todo-item-card-modal.component.ts
+++ b/frontend/src/app/components/todo-item-card-modal/todo-item-card-modal.component.ts
@@ -129,6 +129,9 @@ export class TodoItemCardModalComponent implements OnInit {
   }
 
   async completeTask() {
+    if (!this.completionQualityFormControl.valid || this.completionQuality === 'N_A') {
+      return;
+    }
     const updatedTodo = await this.todoItemService.update(
       this.data.todoItem.todoItemID,
       {


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Todo monitor "Mark as Done" option now properly disables todo completion


