### PR TITLE
(FIX): Change Diagnostic and Re-assessment fill order

### DIFF
--- a/frontend/src/app/utils/highchart.ts
+++ b/frontend/src/app/utils/highchart.ts
@@ -3,6 +3,8 @@ import LearnerModel, { DimensionType, DimensionValue } from '../models/learner';
 import { AuthUser } from '../models/user';
 import sorting from './sorting';
 
+const FILL_TRANSPARENCY = 0.6;
+
 export interface MenuHandlers {
   onEditData: Function;
   onExport: Function;
@@ -123,13 +125,15 @@ export const createStudentGraph = (
   const series: SeriesOptionsType[] = [];
   series.push({
     type: 'area',
-    name: 'Diagnostic',
-    data: studentDiagnostics,
+    name: 'Reassessment',
+    data: studentReassessments,
+    opacity: FILL_TRANSPARENCY,
   });
   series.push({
     type: 'area',
-    name: 'Reassessment',
-    data: studentReassessments,
+    name: 'Diagnostic',
+    data: studentDiagnostics,
+    opacity: FILL_TRANSPARENCY,
   });
   series.push({
     type: 'line',

--- a/frontend/src/app/utils/highchart.ts
+++ b/frontend/src/app/utils/highchart.ts
@@ -3,7 +3,7 @@ import LearnerModel, { DimensionType, DimensionValue } from '../models/learner';
 import { AuthUser } from '../models/user';
 import sorting from './sorting';
 
-const FILL_TRANSPARENCY = 0.6;
+const FILL_OPACITY = 0.6;
 
 export interface MenuHandlers {
   onEditData: Function;
@@ -127,13 +127,13 @@ export const createStudentGraph = (
     type: 'area',
     name: 'Reassessment',
     data: studentReassessments,
-    opacity: FILL_TRANSPARENCY,
+    opacity: FILL_OPACITY,
   });
   series.push({
     type: 'area',
     name: 'Diagnostic',
     data: studentDiagnostics,
-    opacity: FILL_TRANSPARENCY,
+    opacity: FILL_OPACITY,
   });
   series.push({
     type: 'line',


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Diagnostic is now in front of the Re-assessment graph
- Transparency for both area fills reduced to 0.6:
<img width="624" alt="image" src="https://github.com/encorelab/ck-board/assets/73078183/bb81150d-e02f-4349-a584-b007e6dc2857">




Closes #550 
