### PR TITLE
(FEAT): Learner models set to project level

### DIFF
--- a/backend/src/api/learner.ts
+++ b/backend/src/api/learner.ts
@@ -27,6 +27,13 @@ router.post('/board/many', async (req, res) => {
   res.status(200).json(models);
 });
 
+router.post('/project/many', async (req, res) => {
+  const { projectIDs } = req.body;
+
+  const models = await dalLearnerModel.getByProjects(projectIDs);
+  res.status(200).json(models);
+});
+
 router.post('/:id/addDimension', async (req, res) => {
   const { id } = req.params;
   const { dimension } = req.body;

--- a/backend/src/models/Learner.ts
+++ b/backend/src/models/Learner.ts
@@ -25,8 +25,8 @@ export class LearnerModelModel {
   @prop({ required: true })
   public projectID!: string;
 
-  @prop({ required: true })
-  public boardID!: string;
+  @prop({ required: false })
+  public boardID?: string;
 
   @prop({ required: true })
   public name!: string;

--- a/backend/src/repository/dalBoard.ts
+++ b/backend/src/repository/dalBoard.ts
@@ -9,7 +9,6 @@ import dalProject from './dalProject';
 import dalTag from './dalTag';
 import dalComment from './dalComment';
 import dalVote from './dalVote';
-import dalLearnerModel from './dalLearnerModel';
 
 export const getById = async (id: string) => {
   try {
@@ -69,7 +68,6 @@ export const getAllPersonal = async (projectID: string) => {
 export const create = async (board: BoardModel) => {
   try {
     const savedBoard = await Board.create(board);
-    await dalLearnerModel.createDefaultModels(board.projectID, board.boardID);
     return savedBoard;
   } catch (err) {
     throw new Error(JSON.stringify(err, null, ' '));

--- a/backend/src/repository/dalLearnerModel.ts
+++ b/backend/src/repository/dalLearnerModel.ts
@@ -28,16 +28,12 @@ export const create = async (
   }
 };
 
-export const createDefaultModels = async (
-  projectID: string,
-  boardID: string
-) => {
+export const createDefaultModels = async (projectID: string) => {
   try {
     for (const value of DEFAULT_MODELS) {
       await Learner.create({
         modelID: new mongo.ObjectId().toString(),
         projectID: projectID,
-        boardID: boardID,
         name: value,
         dimensions: [],
         data: [],
@@ -52,6 +48,15 @@ export const getByID = async (modelID: string) => {
   try {
     const model = await Learner.findOne({ modelID });
     return model;
+  } catch (err) {
+    throw new Error(JSON.stringify(err, null, ' '));
+  }
+};
+
+export const getByProjects = async (projectIDs: string[]) => {
+  try {
+    const models = await Learner.find({ projectID: { $in: projectIDs } });
+    return models;
   } catch (err) {
     throw new Error(JSON.stringify(err, null, ' '));
   }
@@ -185,6 +190,7 @@ const dalLearnerModel = {
   createDefaultModels,
   getByID,
   getByBoards,
+  getByProjects,
   addDimension,
   removeDimension,
   addDimensionValues,

--- a/backend/src/repository/dalProject.ts
+++ b/backend/src/repository/dalProject.ts
@@ -2,6 +2,7 @@ import { UnauthorizedError } from '../errors/client.errors';
 import Project, { ProjectModel } from '../models/Project';
 import mongoose from 'mongoose';
 import dalBoard from './dalBoard';
+import dalLearnerModel from './dalLearnerModel';
 import { Role } from '../models/User';
 
 export const getById = async (id: string) => {
@@ -57,6 +58,7 @@ export const addTeacher = async (code: string, userID: string) => {
 export const create = async (project: ProjectModel) => {
   try {
     const savedProject = await Project.create(project);
+    await dalLearnerModel.createDefaultModels(project.projectID);
     return savedProject;
   } catch (err) {
     throw new Error(JSON.stringify(err, null, ' '));

--- a/frontend/src/app/components/ck-monitor/ck-monitor.component.html
+++ b/frontend/src/app/components/ck-monitor/ck-monitor.component.html
@@ -297,7 +297,7 @@
         </table>
       </div>
       <div *ngIf="showModels">
-        <app-learner-models #learner [board]="board"></app-learner-models>
+        <app-learner-models #learner [board]="board" [project]="project"></app-learner-models>
       </div>
       <mat-progress-bar style="margin: 20px; width: 95%" mode="indeterminate" *ngIf="loading"></mat-progress-bar>
       <div class="heading no-workflow-select" *ngIf="!runningTask && !todoIsVisible && !showModels">

--- a/frontend/src/app/components/learner-models/learner-models.component.ts
+++ b/frontend/src/app/components/learner-models/learner-models.component.ts
@@ -5,6 +5,7 @@ import more from 'highcharts/highcharts-more';
 import exporting from 'highcharts/modules/exporting';
 import nodata from 'highcharts/modules/no-data-to-display';
 import { Board } from 'src/app/models/board';
+import { Project } from 'src/app/models/project';
 import LearnerModel, { DimensionType } from 'src/app/models/learner';
 import { AuthUser } from 'src/app/models/user';
 import { LearnerService } from 'src/app/services/learner.service';
@@ -42,6 +43,7 @@ export interface ModelCard {
 })
 export class LearnerModelsComponent implements OnInit {
   @Input() board: Board;
+  @Input() project: Project;
 
   modelCards: ModelCard[] = [];
 
@@ -62,7 +64,9 @@ export class LearnerModelsComponent implements OnInit {
   ) {}
 
   async ngOnInit(): Promise<void> {
-    const models = await this.learnerService.getByBoards([this.board.boardID]);
+    const models = await this.learnerService.getByProjects([
+      this.project.projectID,
+    ]);
     for (const model of models) {
       this.modelCards.push({
         model: model,

--- a/frontend/src/app/models/learner.ts
+++ b/frontend/src/app/models/learner.ts
@@ -7,7 +7,8 @@ export enum DimensionType {
 
 export class LearnerModel {
   modelID: string;
-  boardID: string;
+  projectID: string;
+  boardID?: string;
   name: string;
 
   dimensions: string[]; // name of dimensions, must be unique

--- a/frontend/src/app/services/learner.service.ts
+++ b/frontend/src/app/services/learner.service.ts
@@ -8,6 +8,12 @@ import LearnerModel, { DimensionValue } from '../models/learner';
 export class LearnerService {
   constructor(private http: HttpClient) {}
 
+  getByProjects(projectIDs: string[]): Promise<LearnerModel[]> {
+    return this.http
+      .post<LearnerModel[]>('learner/project/many', { projectIDs })
+      .toPromise();
+  }
+
   getByBoards(boardIDs: string[]): Promise<LearnerModel[]> {
     return this.http
       .post<LearnerModel[]>('learner/board/many', { boardIDs })


### PR DESCRIPTION
<!--  
Please include a summary of the addition/fix. 
-->
## Details

- Learner Models are now at the project level; they can be viewed from any board and will the same learner models
- Any change in any board is propagated at the project level, so changes are now at the project level rather than the board level

#### For existing projects
- For all projects before this change, the learner models seen in CK-Monitor will have an aggregate of all the learner models created in the boards individually i.e if previously your project has 3 boards each with 3 learner models, this change will show a total of 9 learner models at the project level
- This will preserve any existing learner models and you can delete then at your choice without having to export and repopulate an existing learner model



Closes #551 
