### PR TITLE
feat(Login): When SCORE SSO is enabled, show SCORE login in a popup w…

### DIFF
--- a/frontend/src/app/guards/sso.guard.ts
+++ b/frontend/src/app/guards/sso.guard.ts
@@ -17,6 +17,9 @@ export class SsoGuard implements CanActivate {
     _state: RouterStateSnapshot
   ) {
     if (this.userService.loggedIn) {
+      if (window.opener != null) {
+        window.opener.postMessage('loadAttemptedUrl', '*');
+      }
       return true;
     } else {
       if (await this.userService.isSsoEnabled()) {

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -7,6 +7,7 @@ import User, { AuthUser, TokenResponse } from '../models/user';
 })
 export class UserService {
   redirectUrl: string | null = null;
+  signInWindow: any;
 
   constructor(private http: HttpClient) {}
 
@@ -59,13 +60,31 @@ export class UserService {
   }
 
   async trySsoLogin(attemptedUrl: string): Promise<any> {
+    this.addLoadAttemptedUrlListener(attemptedUrl);
     return this.http
       .get('auth/sso/handshake')
       .toPromise()
       .then((response: any) => {
-        window.location.href = `${response.scoreSsoEndpoint}?sig=${response.sig}&sso=${response.sso}&redirectUrl=${attemptedUrl}`;
+        this.openSignInWindow(response, attemptedUrl);
         return false;
       });
+  }
+
+  addLoadAttemptedUrlListener(attemptedUrl: string): void {
+    window.addEventListener('message', (event) => {
+      if (event.data === 'loadAttemptedUrl') {
+        window.location.href = attemptedUrl;
+        this.signInWindow.close();
+      }
+    });
+  }
+
+  openSignInWindow(response: any, attemptedUrl: string): void {
+    const ssoEndpoint =
+      response.scoreSsoEndpoint +
+      `?sig=${response.sig}&sso=${response.sso}&redirectUrl=${attemptedUrl}`;
+    const params = 'width=800,height=600';
+    this.signInWindow = window.open(ssoEndpoint, 'SCORE Login Window', params);
   }
 
   async ssoLogin(sso: string | null, sig: string | null): Promise<boolean> {


### PR DESCRIPTION
## Changes

When SCORE SSO is enabled and the user is not logged in and visits a CK Board url, a window will pop up with the SCORE login page. After the user logs in, the popup window will close and the original window will be redirected to the url the user originally attempted to visit.

## Test

Test the SCORE login popup
1. Make sure SCORE SSO is enabled
2. Make sure you are logged out of SCORE and CK Board
3. Go to a CK Board url like these below but with real urls

Project URL
```http://localhost:4201/project/12345678-abcd-1234-abcd-123456789012```

Board URL
```http://localhost:4201/project/12345678-abcd-1234-abcd-123456789012/board/abcdefgh-1234-abcd-1234-abcdefghijkl```

4. When the SCORE login window pops up, sign in with your SCORE username and password
5. The popup window should close and the original window should load the original url you attempted to visit

Closes #565
