### PR TITLE
Add ctrl+click and right-click shortkeys for panning the canvas with …

### DIFF
--- a/frontend/src/app/components/canvas/canvas.component.html
+++ b/frontend/src/app/components/canvas/canvas.component.html
@@ -66,21 +66,23 @@
             *ngIf="mode === modeType.EDIT"
             mat-fab
             color="accent"
-            matTooltip="Mode: Move Posts"
+            matTooltip="Switch to Move Posts Mode"
             matTooltipPosition="before"
             (click)="enablePanMode()"
           >
-            <mat-icon>open_with</mat-icon>
+          <span style="padding-left: 1px;" class="material-symbols-outlined">
+            arrow_selector_tool
+          </span>
           </button>
           <button
             *ngIf="mode === modeType.PAN"
             mat-fab
             color="accent"
-            matTooltip="Mode: Pan Canvas"
+            matTooltip="Switch to Pan Mode (Right-click/Ctrl+click)"
             matTooltipPosition="before"
             (click)="enableEditMode()"
           >
-            <mat-icon style="padding-right: 3px">pan_tool</mat-icon>
+            <mat-icon style="padding-right: 3px;">pan_tool</mat-icon>
           </button>
         </div>
       </div>

--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -79,7 +79,7 @@ export class CanvasComponent implements OnInit, OnDestroy {
 
   zoom = 1;
 
-  ctrlPressed = false;  
+  ctrlPressed = false;
   rightClickDown = false;
 
   mode: Mode = Mode.EDIT;
@@ -714,7 +714,6 @@ export class CanvasComponent implements OnInit, OnDestroy {
     document.addEventListener('keydown', (event) => {
       /* Switch to pan mode on Ctrl press, only if not already holding right-click down */
       if (!this.rightClickDown && event.key === 'Control') {
-
         this.ctrlPressed = true;
         this.prevMode = this.mode;
         this.enablePanMode();
@@ -734,7 +733,7 @@ export class CanvasComponent implements OnInit, OnDestroy {
       if (document.removeAllListeners) {
         document.removeAllListeners('keydown');
         document.removeAllListeners('keyup');
-      }  
+      }
     };
   }
 
@@ -900,7 +899,7 @@ export class CanvasComponent implements OnInit, OnDestroy {
         const options = opt.e as unknown as WheelEvent;
         this.initialClientX = options.clientX;
         this.initialClientY = options.clientY;
-      } 
+      }
     };
 
     const mouseUp = (opt) => {

--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -712,18 +712,30 @@ export class CanvasComponent implements OnInit, OnDestroy {
 
   initCtrlKeyListener() {
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'Control') {
-          this.ctrlPressed = true;
-          this.enablePanMode();
+      /* Switch to pan mode on Ctrl press, only if not already holding right-click down */
+      if (!this.rightClickDown && event.key === 'Control') {
+
+        this.ctrlPressed = true;
+        this.prevMode = this.mode;
+        this.enablePanMode();
       }
     });
 
     document.addEventListener('keyup', (event) => {
       if (event.key === 'Control') {
-          this.ctrlPressed = false;
+        this.ctrlPressed = false;
+        if (this.prevMode === Mode.EDIT) {
           this.enableEditMode();
+        }
       }
     });
+
+    return () => {
+      if (document.removeAllListeners) {
+        document.removeAllListeners('keydown');
+        document.removeAllListeners('keyup');
+      }  
+    };
   }
 
   initPostClickListener() {
@@ -874,7 +886,9 @@ export class CanvasComponent implements OnInit, OnDestroy {
 
     const mouseDown = (opt) => {
       const { e: options } = opt;
-      if (options.button === 2 || options.which === 3) {
+
+      /* Switch to pan mode on right-click, only if ctrl is not already pressed */
+      if (!this.ctrlPressed && (options.button === 2 || options.which === 3)) {
         this.prevMode = this.mode;
         this.enablePanMode();
         this.rightClickDown = true;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -16,7 +16,7 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,700,0,0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0" />
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@0.0.3/dist/confetti.browser.min.js"></script>
   </head>
   <body class="mat-app-background mat-typography">


### PR DESCRIPTION
Added shortkeys for panning canvas with a mouse

## Details

- Ctrl+click or right-click enable panning mode on the canvas
- After right-click or Ctrl-click, mode will be returned to original mode
- Swap move post mode icon on canvas and update tooltips

Closes #579 
