### PR TITLE
Added download chat history button for AI Assistant

### DIFF
--- a/backend/src/api/chatHistory.ts
+++ b/backend/src/api/chatHistory.ts
@@ -1,0 +1,45 @@
+// backend/src/api/chatHistory.ts
+
+import { Router } from 'express';
+import dalChatMessage from '../repository/dalChatMessage';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const { boardId, userId } = req.body;
+    const chatHistory = await dalChatMessage.getByBoardIdAndUserId(
+      boardId,
+      userId
+    );
+
+    // Format the chat history as a CSV string
+    const csvString = formatChatHistoryAsCSV(chatHistory);
+
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="chat_history.csv"'
+    );
+    res.send(csvString);
+  } catch (error) {
+    console.error('Error fetching or formatting chat history:', error);
+    res.status(500).json({ error: 'Failed to download chat history.' });
+  }
+});
+
+function formatChatHistoryAsCSV(chatHistory: any[]): string {
+  // 1. Create header row
+  let csvString = 'Timestamp,Role,Content\n';
+
+  // 2. Add data rows
+  for (const message of chatHistory) {
+    csvString += `"${message.createdAt.toLocaleString()}","${
+      message.role
+    }","${message.content.replace(/"/g, '""')}"\n`;
+  }
+
+  return csvString;
+}
+
+export default router;

--- a/backend/src/models/ChatMessage.ts
+++ b/backend/src/models/ChatMessage.ts
@@ -1,0 +1,21 @@
+import { prop, getModelForClass, modelOptions } from '@typegoose/typegoose';
+
+@modelOptions({
+  schemaOptions: { collection: 'chatMessages', timestamps: true },
+})
+export class ChatMessageModel {
+  @prop({ required: true })
+  public userId!: string;
+
+  @prop({ required: true })
+  public boardId!: string;
+
+  @prop({ required: true, enum: ['user', 'assistant'] })
+  public role!: string;
+
+  @prop({ required: true })
+  public content!: string;
+}
+
+const ChatMessage = getModelForClass(ChatMessageModel);
+export default ChatMessage;

--- a/backend/src/repository/dalChatMessage.ts
+++ b/backend/src/repository/dalChatMessage.ts
@@ -1,0 +1,31 @@
+import ChatMessage, { ChatMessageModel } from '../models/ChatMessage';
+
+export const save = async (message: ChatMessageModel) => {
+  try {
+    const savedMessage = await ChatMessage.create(message);
+    return savedMessage;
+  } catch (err) {
+    throw new Error(JSON.stringify(err, null, ' '));
+  }
+};
+
+export const getByBoardIdAndUserId = async (
+  boardId: string,
+  userId: string
+) => {
+  try {
+    const messages = await ChatMessage.find({ boardId, userId }).sort({
+      createdAt: 1,
+    }); // Sort by createdAt in descending order (oldest to most recent)
+    return messages;
+  } catch (err) {
+    throw new Error(JSON.stringify(err, null, ' '));
+  }
+};
+
+const dalChatMessage = {
+  save,
+  getByBoardIdAndUserId,
+};
+
+export default dalChatMessage;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -22,6 +22,7 @@ import learner from './api/learner';
 import { isAuthenticated } from './utils/auth';
 import RedisClient from './utils/redis';
 import aiRouter from './api/ai';
+import chatHistoryRouter from './api/chatHistory'; 
 dotenv.config();
 
 const port = process.env.PORT || 8001;
@@ -68,6 +69,7 @@ app.use('/api/trace', isAuthenticated, trace);
 app.use('/api/todoItems', isAuthenticated, todoItems);
 app.use('/api/learner', isAuthenticated, learner);
 app.use('/api/ai', isAuthenticated, aiRouter);
+app.use('/api/chat-history', chatHistoryRouter);
 
 app.get('*', (req, res) => {
   res.sendFile(path.join(staticFilesPath, 'index.html'));

--- a/backend/src/socket/events/ai.events.ts
+++ b/backend/src/socket/events/ai.events.ts
@@ -1,4 +1,3 @@
-// ai.events.ts
 import { Server, Socket } from 'socket.io';
 import { SocketEvent } from '../../constants';
 import { sendMessage } from '../../services/vertexAI';
@@ -6,9 +5,10 @@ import { SocketPayload } from '../types/event.types'; // Import the type for Soc
 
 // Define a type for the AI message data
 interface AiMessageData {
-  boardID: string;
   posts: any[]; // Or a more specific type for your posts
   prompt: string;
+  boardId: string;
+  userId: string;
 }
 
 class AiMessage {
@@ -16,18 +16,20 @@ class AiMessage {
 
   static async handleEvent(
     data: SocketPayload<AiMessageData>
-  ): Promise<{ posts: any[]; prompt: string }> {
-    const { posts, prompt } = data.eventData;
+  ): Promise<{ posts: any[]; prompt: string; boardId: string; userId: string }> {
+    const { posts, prompt, boardId, userId } = data.eventData;
     // ... any necessary data processing or validation ...
-    return { posts, prompt };
+    return { posts, prompt, boardId, userId };
   }
 
   static async handleResult(
     io: Server,
     socket: Socket,
-    result: { posts: any[]; prompt: string; boardID: string }
+    result: { posts: any[]; prompt: string; boardId: string; userId: string }
   ): Promise<void> {
-    const { posts, prompt } = result;
+    const { posts, prompt, boardId, userId } = result;
+    socket.data.boardId = boardId;
+    socket.data.userId = userId;
     sendMessage(posts, prompt, socket);
   }
 }

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.html
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.html
@@ -618,8 +618,11 @@
     <mat-label>Ask the AI Assistant</mat-label>
     <input matInput [(ngModel)]="aiPrompt" (keyup.enter)="askAI()" #aiInput /> 
   </mat-form-field>
-  <button mat-raised-button color="primary" (click)="askAI()" *ngIf="selected.value === 3">Send</button>
-
+  <div style="display: flex; gap: 10px;"> 
+    <button mat-raised-button color="primary" (click)="askAI()" *ngIf="selected.value === 3">Send</button>
+    <button mat-raised-button color="primary" (click)="downloadChatHistory()" *ngIf="selected.value === 3">Download Chat History</button>
+  </div>
+  
   <button mat-button (click)="onNoClick()">Close</button>
   <button
     mat-button


### PR DESCRIPTION
For the AI Assistant, log all chat messages to the data base and create a download button where each teacher can download their own chat history.

## Details

-  Create a database schema for saving chat logs, including the teacher's user ID, role (whether user or assistant), the timestamp, the board ID, and the content
- Each time a user creates a prompt, save the prompt with the 'user' role
- Each time the AI assistant creates a response, save the response with the 'assistant' role
- Create a Download Chat History button in the AI assistant tab
- When the download button is pressed, retrieve the entire chat history and save as a CSV file that is downloaded by the client

**Test:**

 - Ensure all previous AI Assistant commands work (creating a bucket, move a post, access vote, tag, title, and content data from posts)
 - Log history can be downloaded when history is empty and has content
 - Different teachers should download only their own chat history

Closes #625 
