### PR TITLE
644 feature re implement ai assistant with manual history

### DIFF
--- a/backend/src/api/chatHistory.ts
+++ b/backend/src/api/chatHistory.ts
@@ -7,7 +7,7 @@ const router = Router();
 
 router.post('/', async (req, res) => {
   try {
-    const { boardId, userId } = req.body;
+    const { boardId, userId, filename } = req.body;
     const chatHistory = await dalChatMessage.getByBoardIdAndUserId(
       boardId,
       userId
@@ -19,7 +19,7 @@ router.post('/', async (req, res) => {
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader(
       'Content-Disposition',
-      'attachment; filename="chat_history.csv"'
+      `attachment; filename="${filename}"`
     );
     res.send(csvString);
   } catch (error) {

--- a/backend/src/api/chatHistory.ts
+++ b/backend/src/api/chatHistory.ts
@@ -17,10 +17,7 @@ router.post('/', async (req, res) => {
     const csvString = formatChatHistoryAsCSV(chatHistory);
 
     res.setHeader('Content-Type', 'text/csv');
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="${filename}"`
-    );
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.send(csvString);
   } catch (error) {
     console.error('Error fetching or formatting chat history:', error);

--- a/backend/src/services/vertexAI/index.ts
+++ b/backend/src/services/vertexAI/index.ts
@@ -356,7 +356,8 @@ function removeEnd(str: string): string {
 
 async function sendMessage(
   posts: any[],
-  prompt: string,
+  currentPrompt: string,
+  fullPromptHistory: string,
   socket: socketIO.Socket
 ): Promise<void> {
   try {
@@ -371,7 +372,7 @@ async function sendMessage(
       userId: userId, 
       boardId: boardId,
       role: 'user',
-      content: prompt 
+      content: currentPrompt 
     });
 
     // 1. Fetch Upvote Counts and Create Map
@@ -398,7 +399,7 @@ async function sendMessage(
     const mappedBuckets = replaceIds(bucketsToSend, postMap, bucketMap);
 
     // 6. Construct and Send Message to LLM (streaming)
-    constructAndSendMessage(mappedPosts, mappedBuckets, prompt).then(
+    constructAndSendMessage(mappedPosts, mappedBuckets, fullPromptHistory).then(
       (result) => {
         // Use .then() to handle the Promise
         const stream = result.stream;

--- a/backend/src/services/vertexAI/index.ts
+++ b/backend/src/services/vertexAI/index.ts
@@ -161,8 +161,6 @@ const generativeModel = vertexAI.preview.getGenerativeModel({
                       posts without creating the bucket first.`,
 });
 
-const chat = generativeModel.startChat({});
-
 function parseVertexAIError(errorString: string): ErrorInfo {
   try {
     const jsonMatch = errorString.match(/{.*}/);
@@ -737,6 +735,8 @@ async function constructAndSendMessage(
       ]
     }
 
+    Remember to use json markdown to wrap this entire response.
+
     Here are the posts from the project:` +
     postsAsKeyValuePairs + // Concatenate variables here
     `\nHere are the buckets:\n` +
@@ -744,11 +744,10 @@ async function constructAndSendMessage(
     `\nUser prompt: ${prompt}`;
 
   try {
-    const result = await chat.sendMessageStream(message); // Get the StreamGenerateContentResult
-
+    const result = await generativeModel.generateContentStream(message);
     return result;
   } catch (error) {
-    console.error('Error in sendMessageStream:', error);
+    console.error('Error in generateContentStream:', error);
     throw error;
   }
 }

--- a/backend/src/socket/events/ai.events.ts
+++ b/backend/src/socket/events/ai.events.ts
@@ -6,7 +6,8 @@ import { SocketPayload } from '../types/event.types'; // Import the type for Soc
 // Define a type for the AI message data
 interface AiMessageData {
   posts: any[]; // Or a more specific type for your posts
-  prompt: string;
+  currentPrompt: string;
+  fullPromptHistory: string;
   boardId: string;
   userId: string;
 }
@@ -16,21 +17,21 @@ class AiMessage {
 
   static async handleEvent(
     data: SocketPayload<AiMessageData>
-  ): Promise<{ posts: any[]; prompt: string; boardId: string; userId: string }> {
-    const { posts, prompt, boardId, userId } = data.eventData;
+  ): Promise<{ posts: any[]; currentPrompt: string; fullPromptHistory: string; boardId: string; userId: string }> {
+    const { posts, currentPrompt, fullPromptHistory: fullPromptHistory, boardId, userId } = data.eventData;
     // ... any necessary data processing or validation ...
-    return { posts, prompt, boardId, userId };
+    return { posts, currentPrompt, fullPromptHistory: fullPromptHistory, boardId, userId };
   }
 
   static async handleResult(
     io: Server,
     socket: Socket,
-    result: { posts: any[]; prompt: string; boardId: string; userId: string }
+    result: { posts: any[]; currentPrompt: string; fullPromptHistory: string; boardId: string; userId: string }
   ): Promise<void> {
-    const { posts, prompt, boardId, userId } = result;
+    const { posts, currentPrompt, fullPromptHistory, boardId, userId } = result;
     socket.data.boardId = boardId;
     socket.data.userId = userId;
-    sendMessage(posts, prompt, socket);
+    sendMessage(posts, currentPrompt, fullPromptHistory, socket);
   }
 }
 

--- a/backend/src/socket/events/ai.events.ts
+++ b/backend/src/socket/events/ai.events.ts
@@ -17,16 +17,40 @@ class AiMessage {
 
   static async handleEvent(
     data: SocketPayload<AiMessageData>
-  ): Promise<{ posts: any[]; currentPrompt: string; fullPromptHistory: string; boardId: string; userId: string }> {
-    const { posts, currentPrompt, fullPromptHistory: fullPromptHistory, boardId, userId } = data.eventData;
+  ): Promise<{
+    posts: any[];
+    currentPrompt: string;
+    fullPromptHistory: string;
+    boardId: string;
+    userId: string;
+  }> {
+    const {
+      posts,
+      currentPrompt,
+      fullPromptHistory: fullPromptHistory,
+      boardId,
+      userId,
+    } = data.eventData;
     // ... any necessary data processing or validation ...
-    return { posts, currentPrompt, fullPromptHistory: fullPromptHistory, boardId, userId };
+    return {
+      posts,
+      currentPrompt,
+      fullPromptHistory: fullPromptHistory,
+      boardId,
+      userId,
+    };
   }
 
   static async handleResult(
     io: Server,
     socket: Socket,
-    result: { posts: any[]; currentPrompt: string; fullPromptHistory: string; boardId: string; userId: string }
+    result: {
+      posts: any[];
+      currentPrompt: string;
+      fullPromptHistory: string;
+      boardId: string;
+      userId: string;
+    }
   ): Promise<void> {
     const { posts, currentPrompt, fullPromptHistory, boardId, userId } = result;
     socket.data.boardId = boardId;

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
@@ -511,52 +511,57 @@ export class CreateWorkflowModalComponent implements OnInit, OnDestroy {
 
   // Helper function to construct the prompt with chat history
   constructPromptWithHistory(currentPrompt: string): string {
-    let fullPrompt = "";
-    
+    let fullPrompt = '';
+
     // Add each message from the chat history to the prompt
-    this.chatHistory.forEach(message => {
+    this.chatHistory.forEach((message) => {
       fullPrompt += `${message.role}: ${message.content}\n`;
     });
 
     // Add the current prompt at the end
-    fullPrompt += `user: ${currentPrompt}`; 
+    fullPrompt += `user: ${currentPrompt}`;
 
     return fullPrompt;
   }
 
   downloadChatHistory() {
     // Generate timestamp in the desired format
-    const timestamp = new Date().toLocaleDateString('en-CA', { 
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false
-  }).replace(/\//g, '-').replace(/, /g, '-'); 
+    const timestamp = new Date()
+      .toLocaleDateString('en-CA', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      })
+      .replace(/\//g, '-')
+      .replace(/, /g, '-');
 
-  const filename = `chat_history-${timestamp}.csv`;
+    const filename = `chat_history-${timestamp}.csv`;
 
-  const data = {
-    boardId: this.board.boardID,
-    userId: this.user.userID,
-    filename: filename // Add filename to the data
-  };
+    const data = {
+      boardId: this.board.boardID,
+      userId: this.user.userID,
+      filename: filename, // Add filename to the data
+    };
 
-    this.http.post('chat-history', data, { 
-      responseType: 'blob' 
-    }).subscribe(
-      (response) => {
-        const blob = new Blob([response], { type: 'text/csv' });
-        saveAs(blob, filename); 
-        this.openSnackBar('Chat history downloaded successfully!');
-      },
-      (error) => {
-        console.error('Error downloading chat history:', error);
-        this.openSnackBar(`Error downloading chat history: ${error.message}`); 
-      }
-    );
+    this.http
+      .post('chat-history', data, {
+        responseType: 'blob',
+      })
+      .subscribe(
+        (response) => {
+          const blob = new Blob([response], { type: 'text/csv' });
+          saveAs(blob, filename);
+          this.openSnackBar('Chat history downloaded successfully!');
+        },
+        (error) => {
+          console.error('Error downloading chat history:', error);
+          this.openSnackBar(`Error downloading chat history: ${error.message}`);
+        }
+      );
   }
 
   private escapeJsonResponse(response: string): string {

--- a/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
+++ b/frontend/src/app/components/create-workflow-modal/create-workflow-modal.component.ts
@@ -424,10 +424,13 @@ export class CreateWorkflowModalComponent implements OnInit, OnDestroy {
 
     // 1. Fetch all posts for the current board
     this.fetchBoardPosts().then((posts) => {
-      const prompt = this.aiPrompt;
+      const currentPrompt = this.aiPrompt;
       this.aiPrompt = ''; // Clear the prompt field
+      
+      // Construct the complete prompt including chat history
+      const prompt = this.constructPromptWithHistory(currentPrompt);
 
-      this.chatHistory.push({ role: 'user', content: prompt });
+      this.chatHistory.push({ role: 'user', content: currentPrompt });
 
       // Wait for the change detection to run and render the new message
       this.changeDetectorRef.detectChanges();
@@ -503,6 +506,21 @@ export class CreateWorkflowModalComponent implements OnInit, OnDestroy {
       );
     });
     this.isProcessingAIRequest = false;
+  }
+
+  // Helper function to construct the prompt with chat history
+  constructPromptWithHistory(currentPrompt: string): string {
+    let fullPrompt = "";
+    
+    // Add each message from the chat history to the prompt
+    this.chatHistory.forEach(message => {
+      fullPrompt += `${message.role}: ${message.content}\n`;
+    });
+
+    // Add the current prompt at the end
+    fullPrompt += `user: ${currentPrompt}`; 
+
+    return fullPrompt;
   }
 
   downloadChatHistory() {


### PR DESCRIPTION
## Completed

- Added abbreviated IDs and replacement and restoration functions before and after the LLM model calls
- Provide the chat history as context
- Switched from chat to freeform (non-chat) gemini

**Test**

- [x] AI Assistant still operates common commands (e.g., add/remove posts from canvas/buckets and answers questions about the data)
- [x] AI Assistant can recall what it told you in previous messages

Closes #644 
