### PR TITLE
Navigate to Login page on invalid session token

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -38,7 +38,7 @@ router.post('/login', async (req, res) => {
   }
 
   const user = userToToken(foundUser);
-  const token = sign(user, getJWTSecret(), { expiresIn: '2h' });
+  const token = sign(user, getJWTSecret(), { expiresIn: '4h' });
   const expiresAt = addHours(2);
 
   res.status(200).send({ token, user, expiresAt });
@@ -53,7 +53,7 @@ router.post('/register', async (req, res) => {
   const savedUser = await dalUser.create(body);
 
   const user = userToToken(savedUser);
-  const token = sign(user, getJWTSecret(), { expiresIn: '2h' });
+  const token = sign(user, getJWTSecret(), { expiresIn: '4h' });
   const expiresAt = addHours(2);
 
   res.status(200).send({ token, user, expiresAt });


### PR DESCRIPTION
## Completed

- Extended session duration from 2h to 4h
- Modified API Interceptor to navigate to login page on 401 error
- Modified invalid token error to throw 401 error


## Test

- [ ] Verify no unusual browser console or backend errors (other than the one or two 401 errors thrown immediately at the time a resource is requested when the session token has expired)
- [ ] Ensure navigation is routed to the login page when the session expires and a resource is requested

To test, you may need to rebuild the backend and it will be helpful to adjust the session token duration

- Search all files and replace three instances of '4h' with '1m' so that the session will expire after 1 minute
- In backend perform: "rm -r node_modules; npm install; npm run dev" to rebuild
- Login and wait for just over a minute, then attempt to navigate to another page or create a post
- You should be navigated back to the login page with a 401 error

Closes #651 
