### PR TITLE
Fix COIL event bugs

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -58,8 +58,10 @@ router.post('/login', async (req, res) => {
 router.post('/register', async (req, res) => {
   const body = req.body;
 
-  const exists = await dalUser.findByUsername(body.username);
-  if (exists) return res.sendStatus(400);
+  const exists = await dalUser.findByEmail(body.email);
+  if (exists) {
+    return res.status(400).send({message: 'Email already in use.'});
+  }
 
   const savedUser = await dalUser.create(body);
 

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -106,7 +106,11 @@ router.post('/forgot-password', async (req, res) => {
     }
 
     // 5. Send an email to the user with a link containing the token
-    const resetLink = `${process.env.CKBOARD_SERVER_ADDRESS}/reset-password?token=${resetToken}`;
+    const resetLink = `${
+      process.env.CKBOARD_SERVER_ADDRESS!.startsWith('http')
+        ? ''
+        : 'https://'
+    }${process.env.CKBOARD_SERVER_ADDRESS!}/reset-password?token=${resetToken}`;
 
     try {
       await generateEmail(email, 'Password Reset Request', resetLink);

--- a/backend/src/repository/dalProject.ts
+++ b/backend/src/repository/dalProject.ts
@@ -95,11 +95,25 @@ export const create = async (project: ProjectModel) => {
   try {
     const savedProject = await Project.create(project);
     await dalLearnerModel.createDefaultModels(project.projectID);
+
+    // Create "All Students" group after project creation
+    let allStudentsGroup = await dalGroup.getAllStudentsGroup(savedProject.projectID);
+    if (!allStudentsGroup) {
+      await dalGroup.create({
+        groupID: 'all-students-' + savedProject.projectID,
+        projectID: savedProject.projectID,
+        members: [], // Initially empty, students are added when they join
+        name: 'All Students',
+        isDefault: true,
+      });
+    }
+
     return savedProject;
   } catch (err) {
     throw new Error(JSON.stringify(err, null, ' '));
   }
 };
+
 
 export const update = async (id: string, project: Partial<ProjectModel>) => {
   try {

--- a/frontend/src/app/components/ck-buckets/ck-buckets.component.html
+++ b/frontend/src/app/components/ck-buckets/ck-buckets.component.html
@@ -27,9 +27,13 @@
 <div class="container d-flex align-items-center justify-content-center">
   <div class="heading">
     <h1 mat-title style="margin: 0"><span>CK Buckets</span></h1>
-     <span style="flex: 1 1 auto"></span>
-     <button mat-icon-button (click)="refreshBuckets()" matTooltip="Refresh Buckets">
-        <mat-icon>refresh</mat-icon>
+    <span style="flex: 1 1 auto"></span>
+    <button
+      mat-icon-button
+      (click)="refreshBuckets()"
+      matTooltip="Refresh Buckets"
+    >
+      <mat-icon>refresh</mat-icon>
     </button>
     <div
       *ngIf="
@@ -47,7 +51,6 @@
         <mat-icon class="material-icons-outlined">add</mat-icon>
       </button>
     </div>
-
   </div>
   <div class="buckets" cdkDropListGroup>
     <h3
@@ -62,6 +65,7 @@
       *ngFor="let bucket of bucketsOnView; let idx = index"
       cdkDropList
       [cdkDropListData]="bucket.htmlPosts"
+      [cdkDropListDisabled]="dragDisabled"
       (cdkDropListDropped)="dragDropPostInBucket($event)"
       [attr.data-bucket]="bucket.bucketID"
       cdkDropListSortingDisabled
@@ -89,6 +93,7 @@
             <app-html-post
               [post]="post"
               cdkDrag
+              [cdkDragDisabled]="dragDisabled"
               style="width: 100%"
             ></app-html-post>
           </div>

--- a/frontend/src/app/components/ck-buckets/ck-buckets.component.ts
+++ b/frontend/src/app/components/ck-buckets/ck-buckets.component.ts
@@ -1,3 +1,4 @@
+// ck-buckets.component.ts
 import { CdkDragDrop, transferArrayItem } from '@angular/cdk/drag-drop';
 import { ComponentType } from '@angular/cdk/portal';
 import { SocketService } from 'src/app/services/socket.service';
@@ -30,8 +31,8 @@ export class CkBucketsComponent implements OnInit, OnDestroy {
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
   @Input() isModalView = false;
-  @Input() projectID: string; 
-  @Input() boardID: string;  
+  @Input() projectID: string;
+  @Input() boardID: string;
   @Input() embedded: boolean = false;
 
   buckets: any[] = [];
@@ -49,6 +50,8 @@ export class CkBucketsComponent implements OnInit, OnDestroy {
 
   groupEventToHandler: Map<SocketEvent, Function>;
   unsubListeners: Subscription[] = [];
+
+  dragDisabled: boolean = true;
 
   constructor(
     public postService: PostService,

--- a/frontend/src/app/components/ck-workspace/ck-workspace.component.scss
+++ b/frontend/src/app/components/ck-workspace/ck-workspace.component.scss
@@ -1,5 +1,5 @@
 @import './../../../../node_modules/swiper/swiper.min.css';
-@import './../../../../node_modules/swiper/swiper-bundle.min.css'; // Import Swiper styles.
+@import './../../../../node_modules/swiper/swiper-bundle.min.css';
 
 .spinner {
   margin: 70px auto;
@@ -42,8 +42,8 @@
   right: 0;
   bottom: 0;
   top: 0;
-  overflow: auto;
-  height: calc(100vh);
+  overflow: none;
+  min-height: calc(100vh);
 }
 
 .subheader-button {
@@ -71,7 +71,7 @@ mat-sidenav-content {
     display: flex;
     flex-direction: column;
     align-items: center;
-    overflow: hidden;
+    overflow-y: auto;
 
     padding-top: 64px;
 
@@ -129,7 +129,7 @@ mat-sidenav-content {
     }
 
     > div:last-child { // Target the *last* div child
-      margin-bottom: 40px; // Add margin ONLY to the last one
+      margin-bottom: 40px; 
     }
 }
 
@@ -141,7 +141,6 @@ mat-sidenav-content {
 .swiper-container {
   width: 60%;
   max-width: 600px; /*  Keep the max-width  */
-  // ADD THIS:
   margin-left: auto;  
   margin-right: auto;
   position: relative;

--- a/frontend/src/app/components/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/components/forgot-password/forgot-password.component.ts
@@ -20,11 +20,13 @@ export class ForgotPasswordComponent {
         this.invalidCredentials = false;
         this.message =
           'If an account with that email exists, a password reset link has been sent.';
+        this.email = '';
       })
       .catch((error) => {
         this.invalidCredentials = true;
         this.message = 'An error occurred. Please try again later.';
         console.error(error);
+        this.email = '';
       });
   }
 }

--- a/frontend/src/app/components/register/register.component.html
+++ b/frontend/src/app/components/register/register.component.html
@@ -1,3 +1,4 @@
+<!-- register.component.html -->
 <div class="wrapper">
   <div class="container">
     <div class="form-image-wrapper">
@@ -84,7 +85,10 @@
               >Password is required (12-30 characters)</mat-hint
             >
           </mat-form-field>
-          <p *ngIf="invalidCredentials" class="invalid-pass">
+          <p *ngIf="emailExists" class="invalid-pass">
+            Email already in use.
+          </p>
+          <p *ngIf="invalidCredentials && !emailExists" class="invalid-pass">
             Unable to register account!
           </p>
         </div>

--- a/frontend/src/app/components/register/register.component.ts
+++ b/frontend/src/app/components/register/register.component.ts
@@ -38,6 +38,7 @@ export class RegisterComponent {
     Validators.maxLength(30),
   ]);
   invalidCredentials = false;
+  emailExists = false;
   matcher = new MyErrorStateMatcher();
 
   constructor(public userService: UserService, private router: Router) {
@@ -58,6 +59,13 @@ export class RegisterComponent {
     this.userService
       .register(user)
       .then(() => this.router.navigate(['dashboard']))
-      .catch(() => (this.invalidCredentials = true));
+      .catch((error) => {
+        // Check the error message from the server
+        if (error && error.message === 'Email already in use.') {
+          this.emailExists = true;
+        } else {
+          this.invalidCredentials = true;
+        }
+      });
   }
 }

--- a/frontend/src/app/components/score-authoring/score-authoring.component.scss
+++ b/frontend/src/app/components/score-authoring/score-authoring.component.scss
@@ -11,7 +11,7 @@
 
 .main-content {
   display: flex; 
-  height: calc(100vh - 64px);  
+  min-height: calc(100vh - 64px);  
   margin-top: 64px; 
 }
 
@@ -247,7 +247,7 @@
   top: 0;
   left: 0;
   width: 100%; 
-  height: 100%; 
+  min-height: 100%; 
   padding: 1rem;
 
   background-color: #fff; 


### PR DESCRIPTION
**Completed**

- Prevent dragging of posts between buckets in CK Buckets component
- Allow workspace to scroll for large posts
- Added https to password reset link if http is not already specified in the server name
- Cleared email address field when forgot password reset link is requested
- Added https to password reset link if http is not already specified in the server name
- Cleared email address field when forgot password reset link is requested
- Removed enforcement of unique display name
- Set enforcement of unique email
- Display email already in use error if appropriate on registration

**Test**

- [x] Cannot create a new user if email already exists
- [x] Verify that email already exists error is appropriately displayed for above case
- [x] Can create a new user with the same display name as another user
- [x] On forgot password reset link request, verify that email field is cleared after request is made
- [x] Verify that link works on local host and will need to test again in the future on the production server
- [x] Verify that in CK Buckets component, posts can no longer be dragged between buckets but can still be opened
- [x] Verify on Workspace that when post contents are very long that the user can scroll down to still see the group list below.

Closes #672 
