### PR TITLE
Added display attributes for bucket posts

### DIFF
--- a/frontend/src/app/components/ck-workspace/ck-workspace.component.ts
+++ b/frontend/src/app/components/ck-workspace/ck-workspace.component.ts
@@ -944,19 +944,22 @@ export class CkWorkspaceComponent implements OnInit, OnDestroy {
           const destinationType =
             PostType[this.runningGroupTask?.workflow.destinations[0].type];
           post.type = destinationType;
+          // 1. Create and assign displayAttributes for ALL posts unconditionally.
+          const displayAttributes: DisplayAttributes = {
+            position: {
+              left: 150,
+              top: 150,
+            },
+            lock: !this.board.permissions.allowStudentMoveAny,
+            fillColor: this.defaultPostFill(),
+          };
+          post.displayAttributes = displayAttributes;
+
+          // 2. The if/else block now only needs to handle properties that are different, like the boardID.
           if (destinationType === PostType.BUCKET) {
             post.boardID = this.board.boardID;
           } else {
-            const displayAttributes: DisplayAttributes = {
-              position: {
-                left: 150,
-                top: 150,
-              },
-              lock: !this.board.permissions.allowStudentMoveAny,
-              fillColor: this.defaultPostFill(),
-            };
             post.boardID = this.runningGroupTask?.workflow.destinations[0].id;
-            post.displayAttributes = displayAttributes;
           }
           const htmlPost = await this.converters.toHTMLPost(post);
           this.submittedPosts.push(htmlPost);


### PR DESCRIPTION
Added display attribute coordinates for posts created in CK Workspace with bucket destinations

## TODO

- Test that posts are created in ck workspace with bucket destination without error
- Confirm that if these posts are moved to the canvas that they have position coordinates on the canvas
- Verify that this resolved the previous issue with displayAttributes error in dalPost.ts


Closes #690 
